### PR TITLE
#341 Hide Suite name when there is only one suite in a plan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "dg-content-control",
-      "version": "1.77.0",
+      "version": "1.78.0",
       "license": "ISC",
       "dependencies": {
         "-": "0.0.1",
-        "@elisra-devops/docgen-data-provider": "^1.47.0",
+        "@elisra-devops/docgen-data-provider": "^1.48.0",
         "@elisra-devops/docgen-skins": "^0.19.0",
         "@types/html-minifier-terser": "^7.0.2",
         "axios": "^1.7.2",
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@elisra-devops/docgen-data-provider": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.47.0.tgz",
-      "integrity": "sha512-IkFQMoVWQ2PmoA3zfwySDqTNOjuT/Ir5g6lmcoMJsqKAeZ64Uq6K1t29fI2wOg3dRqffkqtg1smCw6f4+LLjjA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.48.0.tgz",
+      "integrity": "sha512-iK/dAiv8iT1VgqljBhSviadhVenrEKLTJbhd9rpzMgRC9brooGQ2SfYsK8XTc1A9YOveWSZ0wxmSkCQj1IMZAw==",
       "license": "ISC",
       "dependencies": {
         "@types/xml2js": "^0.4.5",
@@ -7438,9 +7438,9 @@
       }
     },
     "@elisra-devops/docgen-data-provider": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.47.0.tgz",
-      "integrity": "sha512-IkFQMoVWQ2PmoA3zfwySDqTNOjuT/Ir5g6lmcoMJsqKAeZ64Uq6K1t29fI2wOg3dRqffkqtg1smCw6f4+LLjjA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.48.0.tgz",
+      "integrity": "sha512-iK/dAiv8iT1VgqljBhSviadhVenrEKLTJbhd9rpzMgRC9brooGQ2SfYsK8XTc1A9YOveWSZ0wxmSkCQj1IMZAw==",
       "requires": {
         "@types/xml2js": "^0.4.5",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "ISC",
   "dependencies": {
     "-": "0.0.1",
-    "@elisra-devops/docgen-data-provider": "^1.47.0",
+    "@elisra-devops/docgen-data-provider": "^1.48.0",
     "@elisra-devops/docgen-skins": "^0.19.0",
     "@types/html-minifier-terser": "^7.0.2",
     "axios": "^1.7.2",


### PR DESCRIPTION
- updated dataprovider with heirarchy fix