### PR TITLE
feat(svd): add baseline SVD mode for first-run pipeline and release d…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.126.1",
       "license": "ISC",
       "dependencies": {
-        "@elisra-devops/docgen-data-provider": "^1.111.0",
+        "@elisra-devops/docgen-data-provider": "^1.112.0",
         "@elisra-devops/docgen-skins": "^0.24.0",
         "@types/html-minifier-terser": "^7.0.2",
         "axios": "^1.7.2",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@elisra-devops/docgen-data-provider": {
-      "version": "1.111.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.111.0.tgz",
-      "integrity": "sha512-o+UIFfjX04atp3mGLywih4nBvHgmq7l0VJW4ugs9LoywqLAHzQY0eFXcFFMOajsDExAsIo0YIkvv3txqAstqmg==",
+      "version": "1.112.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.112.0.tgz",
+      "integrity": "sha512-2JHgQ51RkicyySRgeEJVb7l1H4Rw4z6BMo2o3oPmkS0YtWejSI1voBELhG+5VskBAYI+fH1wmHB2ZAYpCmRsXQ==",
       "license": "ISC",
       "dependencies": {
         "@types/xml2js": "^0.4.5",
@@ -7530,9 +7530,9 @@
       }
     },
     "@elisra-devops/docgen-data-provider": {
-      "version": "1.111.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.111.0.tgz",
-      "integrity": "sha512-o+UIFfjX04atp3mGLywih4nBvHgmq7l0VJW4ugs9LoywqLAHzQY0eFXcFFMOajsDExAsIo0YIkvv3txqAstqmg==",
+      "version": "1.112.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.112.0.tgz",
+      "integrity": "sha512-2JHgQ51RkicyySRgeEJVb7l1H4Rw4z6BMo2o3oPmkS0YtWejSI1voBELhG+5VskBAYI+fH1wmHB2ZAYpCmRsXQ==",
       "requires": {
         "@types/xml2js": "^0.4.5",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@elisra-devops/docgen-data-provider": "^1.111.0",
+    "@elisra-devops/docgen-data-provider": "^1.112.0",
     "@elisra-devops/docgen-skins": "^0.24.0",
     "@types/html-minifier-terser": "^7.0.2",
     "axios": "^1.7.2",

--- a/src/adapters/ChangesTableDataSkinAdapter.ts
+++ b/src/adapters/ChangesTableDataSkinAdapter.ts
@@ -95,7 +95,7 @@ export default class ChangesTableDataSkinAdapter {
    */
   private applyChangeNumber = (change: any) => {
     if (change.build) {
-      return { value: change.build, url: change.workItem.url };
+      return { value: change.build, url: change.workItem.url || change.workItem._links?.html?.href };
     }
 
     if (change.commit) {
@@ -112,10 +112,11 @@ export default class ChangesTableDataSkinAdapter {
    */
   private applyClosedDateData = (change: any) => {
     if (change.build) {
+      const closedDate = change.workItem.fields?.['Microsoft.VSTS.Common.ClosedDate'];
       return {
-        value:
-          this.convertDateToLocalTime(change.workItem.fields['Microsoft.VSTS.Common.ClosedDate']) ||
-          "This item hasn't been Closed yet",
+        value: closedDate
+          ? this.convertDateToLocalTime(closedDate)
+          : "This item hasn't been Closed yet",
       };
     }
 
@@ -195,7 +196,9 @@ export default class ChangesTableDataSkinAdapter {
                 : 'empty array'
             }`
           );
-          this.adoptedData.push(this.buildNoChangesError(artifactGroup.artifact.name));
+          this.adoptedData.push(
+            this.buildNoChangesError(artifactGroup.artifact.name, artifactGroup.baselineMessage)
+          );
           continue;
         }
 
@@ -205,7 +208,10 @@ export default class ChangesTableDataSkinAdapter {
 
         // Include artifact title only if artifact name is not empty.
         if (artifactGroup.artifact.name !== '') {
-          artifactSection.artifact = this.buildArtifactTitle(artifactGroup.artifact.name);
+          artifactSection.artifact = this.buildArtifactTitle(
+            artifactGroup.artifact.name,
+            artifactGroup.baselineMessage
+          );
         }
 
         const artifactChanges: any[] = [];
@@ -269,14 +275,15 @@ export default class ChangesTableDataSkinAdapter {
   /**
    * Builds an error block when an artifact has no changes to display.
    */
-  private buildNoChangesError(artifactName: string) {
+  private buildNoChangesError(artifactName: string, baselineMessage?: string) {
+    const prefix = baselineMessage ? `${baselineMessage}\n` : '';
     return {
       errorMessage: [
         {
           fields: [
             {
               name: 'Title',
-              value: `No changes found for the requested artifact ${artifactName}`,
+              value: `${prefix}No changes found for the requested artifact ${artifactName}`,
             },
           ],
         },
@@ -288,13 +295,16 @@ export default class ChangesTableDataSkinAdapter {
   /**
    * Builds the artifact section header row.
    */
-  private buildArtifactTitle(artifactName: string) {
+  private buildArtifactTitle(artifactName: string, baselineMessage?: string) {
+    const value = baselineMessage
+      ? `${baselineMessage}\nArtifact name: ${artifactName}`
+      : `Artifact name: ${artifactName}`;
     return [
       {
         fields: [
           {
             name: 'Description',
-            value: `Artifact name: ${artifactName}`,
+            value,
           },
         ],
       },

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -350,6 +350,10 @@ export default class DgContentControls {
             contentControlOptions.data.includeUnlinkedCommits,
             contentControlOptions.data.replaceTaskWithParent,
             contentControlOptions.data.compareMode,
+            {
+              allowBaselineSvd: contentControlOptions.data.allowBaselineSvd,
+              baselineChangeSource: contentControlOptions.data.baselineChangeSource,
+            },
           );
           break;
         case 'pr-change-description-table':
@@ -2026,6 +2030,7 @@ export default class DgContentControls {
     includeUnlinkedCommits: boolean = false,
     replaceTaskWithParent: boolean = false,
     compareMode: 'consecutive' | 'allPairs' = 'consecutive',
+    baselineOptions: any = undefined,
   ) {
     let adoptedChangesData;
     logger.debug(`fetching data with params:
@@ -2070,6 +2075,7 @@ export default class DgContentControls {
         workItemFilterOptions,
         compareMode,
         replaceTaskWithParent,
+        baselineOptions,
       );
       await changeDataFactory.fetchSvdData();
       adoptedChangesData = changeDataFactory.getAdoptedData();

--- a/src/factories/ChangeDataFactory.ts
+++ b/src/factories/ChangeDataFactory.ts
@@ -26,6 +26,14 @@ class SvdRangeResolutionError extends Error {
   }
 }
 
+const PIPELINE_BASELINE_MESSAGE =
+  'Baseline SVD: no previous successful pipeline run was found. The listed items are associated with the current build and establish the baseline.';
+const RELEASE_BASELINE_MESSAGE =
+  'Baseline SVD: no previous successful release run was found. The listed items are associated with the current release run and establish the baseline.';
+const RELEASE_BASELINE_BUILD_ONLY_MESSAGE =
+  `${RELEASE_BASELINE_MESSAGE} Release baseline currently supports Build artifacts only; no Build artifacts were found on the target release.`;
+const BASELINE_WORK_ITEM_CONCURRENCY = 8;
+
 export default class ChangeDataFactory {
   //#region properties
   dgDataProviderAzureDevOps: DgDataProviderAzureDevOps;
@@ -73,6 +81,8 @@ export default class ChangeDataFactory {
   private releasesSeq: any[] = [];
   private releaseIndexByName: Map<string, number> = new Map();
   private replaceTaskWithParent: boolean = false;
+  private allowBaselineSvd: boolean = false;
+  private baselineChangeSource: string = '';
   //#endregion properties
 
   //#region constructor
@@ -104,7 +114,8 @@ export default class ChangeDataFactory {
     formattingSettings: any = {},
     workItemFilterOptions: any = undefined,
     compareMode: 'consecutive' | 'allPairs' = 'consecutive',
-    replaceTaskWithParent: boolean = false
+    replaceTaskWithParent: boolean = false,
+    baselineOptions: any = undefined
   ) {
     this.dgDataProviderAzureDevOps = dgDataProvider;
     this.teamProject = teamProjectName;
@@ -140,6 +151,8 @@ export default class ChangeDataFactory {
     this.pairCompareCache = new Map();
     this.compareMode = compareMode || 'consecutive';
     this.replaceTaskWithParent = !!replaceTaskWithParent;
+    this.allowBaselineSvd = !!baselineOptions?.allowBaselineSvd;
+    this.baselineChangeSource = baselineOptions?.baselineChangeSource || '';
   } //constructor
   // #endregion constructor
 
@@ -805,12 +818,159 @@ export default class ChangeDataFactory {
       artifact: { name: this.tocTitle || '' },
       changes: [...artifactChanges],
       nonLinkedCommits: [...artifactChangesNoLink],
+      baselineMessage: artifactChanges.some((change: any) => change?.isBaselineChange)
+        ? PIPELINE_BASELINE_MESSAGE
+        : undefined,
     });
 
     logger.debug(
       `After push, rawChangesArray[${this.rawChangesArray.length - 1}].changes.length = ${
         this.rawChangesArray[this.rawChangesArray.length - 1].changes.length
       }`
+    );
+  }
+
+  private hasValidExplicitFrom(value: any): boolean {
+    const numericFrom = Number(value);
+    return Number.isFinite(numericFrom) && numericFrom > 0;
+  }
+
+  private canUseBaselineSvd(originalFrom: any, targetId: number): boolean {
+    return (
+      this.requestedByBuild === true &&
+      this.allowBaselineSvd === true &&
+      this.baselineChangeSource === 'currentTargetChanges' &&
+      !this.hasValidExplicitFrom(originalFrom) &&
+      Number.isFinite(targetId) &&
+      targetId > 0
+    );
+  }
+
+  private async getTargetBuildBaselineChanges(
+    pipelinesDataProvider: PipelinesDataProvider,
+    gitDataProvider: GitDataProvider,
+    teamProject: string,
+    buildId: number,
+    baselineReason: string,
+    releaseInfo?: { version?: string; runDate?: string | Date }
+  ): Promise<any[]> {
+    try {
+      if (typeof (pipelinesDataProvider as any).GetBuildWorkItems !== 'function') {
+        throw new SvdRangeResolutionError('Baseline SVD failed: data provider does not support build work item lookup');
+      }
+
+      const workItemRefs = await (pipelinesDataProvider as any).GetBuildWorkItems(teamProject, buildId);
+      if (!Array.isArray(workItemRefs) || workItemRefs.length === 0) {
+        return [];
+      }
+
+      const ticketsDataProvider = await this.dgDataProviderAzureDevOps.getTicketsDataProvider();
+      const changes: any[] = [];
+      const baselineWorkItemIds = new Set<number>();
+      await this.mapWithConcurrency(
+        workItemRefs,
+        BASELINE_WORK_ITEM_CONCURRENCY,
+        async (wi: any) => {
+          const workItemId = wi?.id;
+          if (workItemId === undefined || workItemId === null || workItemId === '') {
+            return;
+          }
+          const populatedWorkItem = await ticketsDataProvider.GetWorkItem(teamProject, String(workItemId));
+          if (!populatedWorkItem) {
+            return;
+          }
+          const numericWorkItemId = Number(populatedWorkItem.id ?? workItemId);
+          if (Number.isFinite(numericWorkItemId) && baselineWorkItemIds.has(numericWorkItemId)) {
+            return;
+          }
+          if (Number.isFinite(numericWorkItemId)) {
+            baselineWorkItemIds.add(numericWorkItemId);
+          }
+          const linkedItems =
+            typeof (gitDataProvider as any).GetLinkedRelatedItemsForSVD === 'function'
+              ? await (gitDataProvider as any).GetLinkedRelatedItemsForSVD(
+                  this.linkedWiOptions,
+                  populatedWorkItem
+                )
+              : [];
+          changes.push({
+            workItem: populatedWorkItem,
+            build: buildId,
+            isBaselineChange: true,
+            baselineReason,
+            releaseVersion: releaseInfo?.version,
+            releaseRunDate: releaseInfo?.runDate,
+            linkedItems,
+          });
+        }
+      );
+      return changes;
+    } catch (e: any) {
+      if (e instanceof SvdRangeResolutionError) {
+        throw e;
+      }
+      throw new SvdRangeResolutionError(`Baseline SVD failed: ${e?.message || e}`);
+    }
+  }
+
+  private async addReleaseBaselineChanges(
+    pipelinesDataProvider: PipelinesDataProvider,
+    gitDataProvider: GitDataProvider,
+    toRelease: any
+  ): Promise<void> {
+    const releaseVersion = toRelease?.name;
+    const releaseRunDate = toRelease?.createdOn || toRelease?.created || toRelease?.createdDate;
+    const buildArtifacts = (toRelease?.artifacts || []).filter(
+      (artifact: any) => String(artifact?.type || '').toLowerCase() === 'build'
+    );
+
+    if (buildArtifacts.length === 0) {
+      this.rawChangesArray.push({
+        artifact: { name: 'Release baseline' },
+        changes: [],
+        nonLinkedCommits: [],
+        baselineMessage: RELEASE_BASELINE_BUILD_ONLY_MESSAGE,
+      });
+      return;
+    }
+
+    for (const artifact of buildArtifacts) {
+      const buildId = Number(artifact?.definitionReference?.version?.id);
+      if (!Number.isFinite(buildId) || buildId <= 0) {
+        continue;
+      }
+      const artifactDisplayName = this.getArtifactDisplayName('Build', artifact);
+      const baselineChanges = await this.getTargetBuildBaselineChanges(
+        pipelinesDataProvider,
+        gitDataProvider,
+        this.teamProject,
+        buildId,
+        RELEASE_BASELINE_MESSAGE,
+        { version: releaseVersion, runDate: releaseRunDate }
+      );
+      this.rawChangesArray.push({
+        artifact: { name: artifactDisplayName },
+        changes: baselineChanges,
+        nonLinkedCommits: [],
+        baselineMessage: RELEASE_BASELINE_MESSAGE,
+      });
+    }
+  }
+
+  private async mapWithConcurrency<T>(
+    items: T[],
+    concurrency: number,
+    worker: (item: T) => Promise<void>
+  ): Promise<void> {
+    let nextIndex = 0;
+    const workerCount = Math.min(concurrency, items.length);
+    await Promise.all(
+      Array.from({ length: workerCount }, async () => {
+        while (nextIndex < items.length) {
+          const currentIndex = nextIndex++;
+          await worker(items[currentIndex]);
+        }
+      })
     );
   }
 
@@ -978,6 +1138,9 @@ export default class ChangeDataFactory {
       }
       if (!previousReleaseId) {
         logger.warn(`Could not find a valid release before release #${toId}`);
+        if (this.canUseBaselineSvd(this.from, toId)) {
+          await this.addReleaseBaselineChanges(pipelinesDataProvider, gitDataProvider, toRelease);
+        }
         return;
       }
       fromId = Number(typeof previousReleaseId === 'object' ? previousReleaseId.id : previousReleaseId);
@@ -1485,7 +1648,17 @@ export default class ChangeDataFactory {
 
         if (!prevRunId) {
           logger.warn(`Could not find a valid pipeline before run #${to}`);
-          return { artifactChanges: [], artifactChangesNoLink: [] };
+          if (this.canUseBaselineSvd(from, targetBuildId)) {
+            const baselineChanges = await this.getTargetBuildBaselineChanges(
+              pipelinesDataProvider,
+              gitDataProvider,
+              teamProject,
+              targetBuildId,
+              PIPELINE_BASELINE_MESSAGE
+            );
+            artifactChanges.push(...baselineChanges);
+          }
+          return { artifactChanges, artifactChangesNoLink };
         }
 
         resolvedFromRunId = Number(typeof prevRunId === 'object' ? prevRunId.id : prevRunId);

--- a/src/models/changeModels.ts
+++ b/src/models/changeModels.ts
@@ -60,6 +60,8 @@ export interface ChangeEntry {
   build?: number | string;
   releaseVersion?: string;
   releaseRunDate?: string | Date;
+  isBaselineChange?: boolean;
+  baselineReason?: string;
 }
 
 export interface NonLinkedCommit {
@@ -76,6 +78,7 @@ export interface ArtifactChangesGroup {
   artifact: ArtifactDescriptor;
   changes: ChangeEntry[];
   nonLinkedCommits: NonLinkedCommit[];
+  baselineMessage?: string;
 }
 
 // Services.json and release attribution models

--- a/src/test/adapters-test/ChangesTableDataSkinAdapter.test.ts
+++ b/src/test/adapters-test/ChangesTableDataSkinAdapter.test.ts
@@ -131,6 +131,71 @@ describe('ChangesTableDataSkinAdapter', () => {
     expect((adapter as any).attachmentMinioData.length).toBeGreaterThan(0);
   });
 
+  test('build work item row uses html link fallback and readable active-state date fallback', async () => {
+    const change = makeWorkItemChange({
+      workItem: {
+        id: 1,
+        _links: { html: { href: 'http://wi/fallback' } },
+        fields: {
+          'System.WorkItemType': 'Bug',
+          'System.Title': 'Active bug',
+          'System.Description': '<p>desc</p>',
+        },
+      },
+    });
+    const groups = [makeArtifactGroup([change])];
+    const adapter = new ChangesTableDataSkinAdapter(
+      groups,
+      true,
+      true,
+      'proj',
+      '/template',
+      'bucket',
+      'endpoint',
+      'access',
+      'secret',
+      'pat',
+      baseFormatting
+    );
+
+    await adapter.adoptSkinData();
+    const fields = adapter.getAdoptedData()[0].artifactChanges[0].fields;
+
+    expect(fields.find((f: any) => f.name === 'Change #').url).toBe('http://wi/fallback');
+    expect(fields.find((f: any) => f.name === 'Committed Date & Time').value).toBe(
+      "This item hasn't been Closed yet"
+    );
+  });
+
+  test('renders baseline notice in artifact header', async () => {
+    const groups = [
+      {
+        ...makeArtifactGroup([makeWorkItemChange()], 'BaselineArtifact'),
+        baselineMessage:
+          'Baseline SVD: no previous successful pipeline run was found. The listed items are associated with the current build and establish the baseline.',
+      },
+    ];
+    const adapter = new ChangesTableDataSkinAdapter(
+      groups as any,
+      true,
+      true,
+      'proj',
+      '/template',
+      'bucket',
+      'endpoint',
+      'access',
+      'secret',
+      'pat',
+      baseFormatting
+    );
+
+    await adapter.adoptSkinData();
+    const data = adapter.getAdoptedData();
+
+    expect(data[0].artifact[0].fields[0].value).toContain('Baseline SVD');
+    expect(data[0].artifact[0].fields[0].value).toContain('Artifact name: BaselineArtifact');
+  });
+
   test('expands linked items into multiple rows and empties base fields for subsequent rows', async () => {
     const linkedChange = makeWorkItemChange({
       linkedItems: [

--- a/src/test/factories-test/ChangeDataFactory.test.ts
+++ b/src/test/factories-test/ChangeDataFactory.test.ts
@@ -89,6 +89,19 @@ describe('ChangeDataFactory', () => {
     mockTicketsDataProvider = {
       GetQueryResultsFromWiql: jest.fn().mockResolvedValue([]),
       GetWorkitemAttachments: jest.fn().mockResolvedValue([]),
+      GetWorkItem: jest.fn().mockImplementation((_project: string, id: string) =>
+        Promise.resolve({
+          id: Number(id),
+          _links: { html: { href: `https://example.test/wi/${id}` } },
+          fields: {
+            'System.WorkItemType': 'Task',
+            'System.Title': `Work item ${id}`,
+            'System.Description': '',
+            'Microsoft.VSTS.Common.ClosedDate': '2026-01-01T00:00:00Z',
+            'Microsoft.VSTS.Common.ClosedBy': { displayName: 'Tester' },
+          },
+        })
+      ),
     };
 
     // Mock Git data provider
@@ -1812,6 +1825,183 @@ describe('ChangeDataFactory', () => {
         expect(mockPipelines.GetReleaseByReleaseId).toHaveBeenCalledWith('TestProject', 10);
       });
 
+      it('fetchReleaseChanges should use target release build work items as baseline when no previous release exists', async () => {
+        const factory = changeDataFactory as any;
+        factory.rangeType = 'release';
+        factory.repoId = '123';
+        factory.from = '';
+        factory.to = '20';
+        factory.requestedByBuild = true;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+
+        const toRelease = {
+          id: 20,
+          name: '2.0.0',
+          createdOn: '2026-01-02T00:00:00Z',
+          releaseDefinition: { id: 123 },
+          environments: [{ status: 'succeeded' }],
+          artifacts: [
+            {
+              type: 'Build',
+              alias: 'AppBuild',
+              definitionReference: {
+                version: { id: '200', name: '200' },
+                definition: { name: 'App Build' },
+              },
+            },
+          ],
+        };
+
+        const mockPipelines = {
+          GetReleaseByReleaseId: jest.fn().mockResolvedValue(toRelease),
+          findPreviousSuccessfulRelease: jest.fn().mockResolvedValue(undefined),
+          GetBuildWorkItems: jest.fn().mockResolvedValue([{ id: '99' }]),
+        } as any;
+
+        await factory.fetchReleaseChanges(mockPipelines, mockGitDataProvider, mockJfrogDataProvider);
+
+        expect(mockPipelines.findPreviousSuccessfulRelease).toHaveBeenCalledWith('TestProject', '123', 20);
+        expect(mockPipelines.GetBuildWorkItems).toHaveBeenCalledWith('TestProject', 200);
+        expect(factory.rawChangesArray[0].baselineMessage).toContain('Baseline SVD');
+        expect(factory.rawChangesArray[0].changes[0]).toMatchObject({
+          build: 200,
+          isBaselineChange: true,
+          releaseVersion: '2.0.0',
+          releaseRunDate: '2026-01-02T00:00:00Z',
+        });
+        expect(factory.rawChangesArray[0].changes[0].workItem.id).toBe(99);
+      });
+
+      it('fetchReleaseChanges should return a clear baseline message when target release has no Build artifacts', async () => {
+        const factory = changeDataFactory as any;
+        factory.rangeType = 'release';
+        factory.repoId = '123';
+        factory.from = '';
+        factory.to = '20';
+        factory.requestedByBuild = true;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+
+        const toRelease = {
+          id: 20,
+          name: '2.0.0',
+          releaseDefinition: { id: 123 },
+          environments: [{ status: 'succeeded' }],
+          artifacts: [
+            {
+              type: 'Git',
+              alias: 'RepoArtifact',
+              definitionReference: {
+                definition: { name: 'Repo Artifact' },
+              },
+            },
+          ],
+        };
+
+        const mockPipelines = {
+          GetReleaseByReleaseId: jest.fn().mockResolvedValue(toRelease),
+          findPreviousSuccessfulRelease: jest.fn().mockResolvedValue(undefined),
+          GetBuildWorkItems: jest.fn(),
+        } as any;
+
+        await factory.fetchReleaseChanges(mockPipelines, mockGitDataProvider, mockJfrogDataProvider);
+
+        expect(mockPipelines.GetBuildWorkItems).not.toHaveBeenCalled();
+        expect(factory.rawChangesArray[0]).toMatchObject({
+          artifact: { name: 'Release baseline' },
+          changes: [],
+          nonLinkedCommits: [],
+        });
+        expect(factory.rawChangesArray[0].baselineMessage).toContain('supports Build artifacts only');
+      });
+
+      it('fetchReleaseChanges should use resolved latest release as baseline target when to is empty', async () => {
+        const factory = changeDataFactory as any;
+        factory.rangeType = 'release';
+        factory.repoId = '123';
+        factory.from = '';
+        factory.to = '';
+        factory.requestedByBuild = true;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+
+        const toRelease = {
+          id: 20,
+          name: '2.0.0',
+          createdOn: '2026-01-02T00:00:00Z',
+          releaseDefinition: { id: 123 },
+          environments: [{ status: 'succeeded' }],
+          artifacts: [
+            {
+              type: 'Build',
+              alias: 'AppBuild',
+              definitionReference: {
+                version: { id: '200', name: '200' },
+                definition: { name: 'App Build' },
+              },
+            },
+          ],
+        };
+
+        const mockPipelines = {
+          findLatestSuccessfulRelease: jest.fn().mockResolvedValue(20),
+          GetReleaseByReleaseId: jest.fn().mockResolvedValue(toRelease),
+          findPreviousSuccessfulRelease: jest.fn().mockResolvedValue(undefined),
+          GetBuildWorkItems: jest.fn().mockResolvedValue([{ id: '99' }]),
+        } as any;
+
+        await factory.fetchReleaseChanges(mockPipelines, mockGitDataProvider, mockJfrogDataProvider);
+
+        expect(mockPipelines.findLatestSuccessfulRelease).toHaveBeenCalledWith('TestProject', '123');
+        expect(mockPipelines.findPreviousSuccessfulRelease).toHaveBeenCalledWith('TestProject', '123', 20);
+        expect(mockPipelines.GetBuildWorkItems).toHaveBeenCalledWith('TestProject', 200);
+        expect(factory.rawChangesArray[0].changes[0].isBaselineChange).toBe(true);
+      });
+
+      it('fetchReleaseChanges should not use baseline mode when an explicit source release is provided', async () => {
+        const factory = changeDataFactory as any;
+        factory.rangeType = 'release';
+        factory.repoId = '123';
+        factory.from = '10';
+        factory.to = '20';
+        factory.requestedByBuild = true;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+
+        const toRelease = {
+          id: 20,
+          name: '2.0.0',
+          releaseDefinition: { id: 123 },
+          environments: [{ status: 'succeeded' }],
+          artifacts: [
+            {
+              type: 'Build',
+              definitionReference: {
+                version: { id: '200', name: '200' },
+                definition: { name: 'App Build' },
+              },
+            },
+          ],
+        };
+
+        const mockPipelines = {
+          GetReleaseByReleaseId: jest.fn().mockImplementation((_tp: string, id: number) => {
+            if (id === 20) return Promise.resolve(toRelease);
+            return Promise.resolve(undefined);
+          }),
+          findPreviousSuccessfulRelease: jest.fn(),
+          GetBuildWorkItems: jest.fn().mockResolvedValue([{ id: '99' }]),
+        } as any;
+
+        await expect(
+          factory.fetchReleaseChanges(mockPipelines, mockGitDataProvider, mockJfrogDataProvider)
+        ).rejects.toThrow('Could not load source release #10');
+
+        expect(mockPipelines.findPreviousSuccessfulRelease).not.toHaveBeenCalled();
+        expect(mockPipelines.GetBuildWorkItems).not.toHaveBeenCalled();
+      });
+
       it('fetchReleaseChanges should throw when latest release discovery method is unavailable', async () => {
         const factory = changeDataFactory as any;
         factory.rangeType = 'release';
@@ -2897,6 +3087,218 @@ describe('ChangeDataFactory', () => {
           0
         );
         expect(pipelines.getPipelineBuildByBuildId).toHaveBeenCalledWith(defaultParams.teamProject, 150);
+      });
+
+      it('GetPipelineChanges should use current target build work items as baseline when no previous run exists', async () => {
+        const factory = changeDataFactory as any;
+        factory.requestedByBuild = true;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+
+        const pipelines: any = {
+          getPipelineBuildByBuildId: jest.fn().mockImplementation((_tp: string, id: number) => {
+            if (id === 200) {
+              return {
+                id,
+                result: 'succeeded',
+                definition: { id: 10 },
+              };
+            }
+            return undefined;
+          }),
+          findPreviousPipeline: jest.fn().mockResolvedValue(undefined),
+          getPipelineRunDetails: jest.fn().mockResolvedValue({}),
+          GetBuildWorkItems: jest.fn().mockResolvedValue([{ id: '99' }]),
+        };
+
+        const result = await factory.GetPipelineChanges(
+          pipelines,
+          mockGitDataProvider,
+          defaultParams.teamProject,
+          200,
+          ''
+        );
+
+        expect(pipelines.findPreviousPipeline).toHaveBeenCalled();
+        expect(pipelines.GetBuildWorkItems).toHaveBeenCalledWith(defaultParams.teamProject, 200);
+        expect(result.artifactChanges[0]).toMatchObject({
+          build: 200,
+          isBaselineChange: true,
+        });
+        expect(result.artifactChanges[0].workItem.id).toBe(99);
+      });
+
+      it('GetPipelineChanges should include linked WI enrichment for baseline work items', async () => {
+        const factory = changeDataFactory as any;
+        factory.requestedByBuild = true;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+        factory.linkedWiOptions = {
+          isEnabled: true,
+          linkedWiTypes: 'both',
+          linkedWiRelationship: 'both',
+        };
+
+        const pipelines: any = {
+          getPipelineBuildByBuildId: jest.fn().mockImplementation((_tp: string, id: number) => {
+            if (id === 200) {
+              return {
+                id,
+                result: 'succeeded',
+                definition: { id: 10 },
+              };
+            }
+            return undefined;
+          }),
+          findPreviousPipeline: jest.fn().mockResolvedValue(undefined),
+          getPipelineRunDetails: jest.fn().mockResolvedValue({}),
+          GetBuildWorkItems: jest.fn().mockResolvedValue([{ id: '99' }]),
+        };
+        mockGitDataProvider.GetLinkedRelatedItemsForSVD = jest.fn().mockResolvedValue([
+          { id: 500, wiType: 'Requirement', title: 'Req 500', relationType: 'Affects' },
+        ]);
+
+        const result = await factory.GetPipelineChanges(
+          pipelines,
+          mockGitDataProvider,
+          defaultParams.teamProject,
+          200,
+          ''
+        );
+
+        expect(mockGitDataProvider.GetLinkedRelatedItemsForSVD).toHaveBeenCalledWith(
+          factory.linkedWiOptions,
+          expect.objectContaining({ id: 99 })
+        );
+        expect(result.artifactChanges[0].linkedItems).toEqual([
+          { id: 500, wiType: 'Requirement', title: 'Req 500', relationType: 'Affects' },
+        ]);
+      });
+
+      it('GetPipelineChanges should cap baseline work item hydration concurrency', async () => {
+        const factory = changeDataFactory as any;
+        factory.requestedByBuild = true;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+
+        let activeCalls = 0;
+        let maxActiveCalls = 0;
+        mockTicketsDataProvider.GetWorkItem = jest.fn().mockImplementation(
+          (_project: string, id: string) =>
+            new Promise((resolve) => {
+              activeCalls++;
+              maxActiveCalls = Math.max(maxActiveCalls, activeCalls);
+              setTimeout(() => {
+                activeCalls--;
+                resolve({
+                  id: Number(id),
+                  _links: { html: { href: `https://example.test/wi/${id}` } },
+                  fields: {
+                    'System.WorkItemType': 'Task',
+                    'System.Title': `Work item ${id}`,
+                    'System.Description': '',
+                  },
+                });
+              }, 5);
+            })
+        );
+
+        const pipelines: any = {
+          getPipelineBuildByBuildId: jest.fn().mockImplementation((_tp: string, id: number) => {
+            if (id === 200) {
+              return {
+                id,
+                result: 'succeeded',
+                definition: { id: 10 },
+              };
+            }
+            return undefined;
+          }),
+          findPreviousPipeline: jest.fn().mockResolvedValue(undefined),
+          getPipelineRunDetails: jest.fn().mockResolvedValue({}),
+          GetBuildWorkItems: jest.fn().mockResolvedValue(
+            Array.from({ length: 20 }, (_v, idx) => ({ id: String(idx + 100) }))
+          ),
+        };
+
+        const result = await factory.GetPipelineChanges(
+          pipelines,
+          mockGitDataProvider,
+          defaultParams.teamProject,
+          200,
+          ''
+        );
+
+        expect(result.artifactChanges).toHaveLength(20);
+        expect(maxActiveCalls).toBeLessThanOrEqual(8);
+      });
+
+      it('GetPipelineChanges should ignore baseline flags when request did not come from the job template', async () => {
+        const factory = changeDataFactory as any;
+        factory.requestedByBuild = false;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+
+        const pipelines: any = {
+          getPipelineBuildByBuildId: jest.fn().mockImplementation((_tp: string, id: number) => {
+            if (id === 200) {
+              return {
+                id,
+                result: 'succeeded',
+                definition: { id: 10 },
+              };
+            }
+            return undefined;
+          }),
+          findPreviousPipeline: jest.fn().mockResolvedValue(undefined),
+          getPipelineRunDetails: jest.fn().mockResolvedValue({}),
+          GetBuildWorkItems: jest.fn().mockResolvedValue([{ id: '99' }]),
+        };
+
+        const result = await factory.GetPipelineChanges(
+          pipelines,
+          mockGitDataProvider,
+          defaultParams.teamProject,
+          200,
+          ''
+        );
+
+        expect(result).toEqual({ artifactChanges: [], artifactChangesNoLink: [] });
+        expect(pipelines.GetBuildWorkItems).not.toHaveBeenCalled();
+      });
+
+      it('GetPipelineChanges should not use baseline mode when an explicit source build is provided', async () => {
+        const factory = changeDataFactory as any;
+        factory.requestedByBuild = true;
+        factory.allowBaselineSvd = true;
+        factory.baselineChangeSource = 'currentTargetChanges';
+
+        const pipelines: any = {
+          getPipelineBuildByBuildId: jest.fn().mockImplementation((_tp: string, id: number) => {
+            if (id === 200) {
+              return {
+                id,
+                result: 'succeeded',
+                definition: { id: 10 },
+              };
+            }
+            return undefined;
+          }),
+          findPreviousPipeline: jest.fn().mockResolvedValue(undefined),
+          getPipelineRunDetails: jest.fn().mockResolvedValue({}),
+          GetBuildWorkItems: jest.fn().mockResolvedValue([{ id: '99' }]),
+        };
+
+        const result = await factory.GetPipelineChanges(
+          pipelines,
+          mockGitDataProvider,
+          defaultParams.teamProject,
+          200,
+          100
+        );
+
+        expect(result).toEqual({ artifactChanges: [], artifactChangesNoLink: [] });
+        expect(pipelines.GetBuildWorkItems).not.toHaveBeenCalled();
       });
 
       it('GetPipelineChanges should throw when previous run discovery fails', async () => {


### PR DESCRIPTION
…ocuments

When no previous successful pipeline run or release exists and allowBaselineSvd=true with baselineChangeSource='currentTargetChanges', fall back to the current target build's linked work items as the baseline content instead of an empty table.

- ChangeDataFactory: add canUseBaselineSvd guard, getTargetBuildBaselineChanges (concurrency cap: 8 via mapWithConcurrency), and addReleaseBaselineChanges for release artifact paths
- changeModels: add isBaselineChange/baselineReason to ChangeEntry; baselineMessage to ArtifactChangesGroup
- ChangesTableDataSkinAdapter: surface baselineMessage in artifact section headers and no-changes error blocks; fix work-item URL to fall back to _links.html.href; fix optional chaining on ClosedDate field access
- controllers/index.ts: thread allowBaselineSvd and baselineChangeSource from request options through to ChangeDataFactory