### PR TITLE
#294937 fix zero-result bug when work-item filter uses display-case v…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.128.3",
       "license": "ISC",
       "dependencies": {
-        "@elisra-devops/docgen-data-provider": "^1.130.0",
+        "@elisra-devops/docgen-data-provider": "^1.131.0",
         "@elisra-devops/docgen-skins": "^0.24.0",
         "@types/html-minifier-terser": "^7.0.2",
         "axios": "^1.7.2",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@elisra-devops/docgen-data-provider": {
-      "version": "1.130.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.130.0.tgz",
-      "integrity": "sha512-bvLuQ9IaQiV8QgL37QfpxVkopUc9yFqPqs9tSVa+nDbJJtJgtgm3c0f8uwTLCNf5veZ/TQfD4qNkSyauwzZ8EA==",
+      "version": "1.131.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.131.0.tgz",
+      "integrity": "sha512-UB7uv2guJvbTdvArVrFMAYM7WkXxA4EdPMOIsB9L1E5XVsEw151GM3i5jYCuGw+huVk0sXvnbykJYkuo19wGTg==",
       "license": "ISC",
       "dependencies": {
         "@types/xml2js": "^0.4.5",
@@ -7530,9 +7530,9 @@
       }
     },
     "@elisra-devops/docgen-data-provider": {
-      "version": "1.130.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.130.0.tgz",
-      "integrity": "sha512-bvLuQ9IaQiV8QgL37QfpxVkopUc9yFqPqs9tSVa+nDbJJtJgtgm3c0f8uwTLCNf5veZ/TQfD4qNkSyauwzZ8EA==",
+      "version": "1.131.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.131.0.tgz",
+      "integrity": "sha512-UB7uv2guJvbTdvArVrFMAYM7WkXxA4EdPMOIsB9L1E5XVsEw151GM3i5jYCuGw+huVk0sXvnbykJYkuo19wGTg==",
       "requires": {
         "@types/xml2js": "^0.4.5",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@elisra-devops/docgen-data-provider": "^1.130.0",
+    "@elisra-devops/docgen-data-provider": "^1.131.0",
     "@elisra-devops/docgen-skins": "^0.24.0",
     "@types/html-minifier-terser": "^7.0.2",
     "axios": "^1.7.2",

--- a/src/factories/ChangeDataFactory.ts
+++ b/src/factories/ChangeDataFactory.ts
@@ -181,6 +181,13 @@ export default class ChangeDataFactory {
       logger.info(
         `[SVD ${svdId}] start teamProject=${this.teamProject}, rangeType=${this.rangeType}, from=${this.from}, to=${this.to}, compareMode=${this.compareMode}, includeUnlinkedCommits=${this.includeUnlinkedCommits}`
       );
+      // 0) Validate work-item filter options against the project's real ADO metadata early,
+      //    before any expensive release/change gathering. Throws with a clear message if any
+      //    workItemType or workItemState value is not known to this project.
+      if (this.workItemFilterOptions?.isEnabled) {
+        await this.validateWorkItemFilterOptions();
+      }
+
       // 1) Get release component adoptedData for release-components content control
       let pipelinesDataProvider = await this.dgDataProviderAzureDevOps.getPipelinesDataProvider();
       if (this.rangeType === 'release') {
@@ -2746,10 +2753,55 @@ export default class ChangeDataFactory {
     return { groups: dedupedGroups, removedChanges };
   }
 
+  /**
+   * Validates the enabled work-item filter options against the project's ADO metadata.
+   * Throws a descriptive error if any workItemType or workItemState value is not recognised
+   * by the project, so callers (e.g. PowerShell release tasks) get immediate feedback
+   * instead of a silent zero-result document.
+   */
+  private async validateWorkItemFilterOptions(): Promise<void> {
+    const ticketsDataProvider = await this.dgDataProviderAzureDevOps.getTicketsDataProvider();
+    const { types, states } = await ticketsDataProvider.GetWorkItemTypeStates(this.teamProject);
+
+    const validTypes = new Set(types.map((t: string) => t.toLowerCase()));
+    const validStates = new Set(states.map((s: string) => s.toLowerCase()));
+
+    const badTypes = (this.workItemFilterOptions.workItemTypes ?? []).filter(
+      (t: string) => !validTypes.has(String(t).toLowerCase())
+    );
+    const badStates = (this.workItemFilterOptions.workItemStates ?? []).filter(
+      (s: string) => !validStates.has(String(s).toLowerCase())
+    );
+
+    if (badTypes.length || badStates.length) {
+      const parts: string[] = [];
+      if (badTypes.length) {
+        parts.push(
+          `invalid work item type(s): [${badTypes.join(', ')}]. Valid: [${types.join(', ')}]`
+        );
+      }
+      if (badStates.length) {
+        parts.push(
+          `invalid work item state(s): [${badStates.join(', ')}]. Valid: [${states.join(', ')}]`
+        );
+      }
+      throw new Error(`SVD work-item filter validation failed — ${parts.join('; ')}`);
+    }
+  }
+
   private filterChangesByWorkItemOptions(changes: any[] = []): any[] {
     if (!this.workItemFilterOptions?.isEnabled) {
       return changes;
     }
+
+    // Normalize filter arrays once — callers may send display-case strings (e.g. "Bug", "Closed")
+    // while ADO field values are lowercased during comparison, so normalize both sides.
+    const allowedTypes = (this.workItemFilterOptions.workItemTypes ?? []).map((t: string) =>
+      String(t).toLowerCase()
+    );
+    const allowedStates = (this.workItemFilterOptions.workItemStates ?? []).map((s: string) =>
+      String(s).toLowerCase()
+    );
 
     const filteredChanges = changes.filter((change) => {
       const workItem = change?.workItem;
@@ -2761,12 +2813,8 @@ export default class ChangeDataFactory {
       const workItemState = String(workItem.fields?.['System.State'] ?? '').toLowerCase();
 
       // if no filters are set, return all changes
-      const isValidType =
-        this.workItemFilterOptions.workItemTypes.length === 0 ||
-        this.workItemFilterOptions.workItemTypes.includes(workItemType);
-      const isValidState =
-        this.workItemFilterOptions.workItemStates.length === 0 ||
-        this.workItemFilterOptions.workItemStates.includes(workItemState);
+      const isValidType = allowedTypes.length === 0 || allowedTypes.includes(workItemType);
+      const isValidState = allowedStates.length === 0 || allowedStates.includes(workItemState);
 
       return isValidType && isValidState;
     });

--- a/src/test/factories-test/ChangeDataFactory.test.ts
+++ b/src/test/factories-test/ChangeDataFactory.test.ts
@@ -105,6 +105,11 @@ describe('ChangeDataFactory', () => {
           },
         })
       ),
+      // Default: project has Bug, Requirement, Change Request / Closed, Resolved, Active, New
+      GetWorkItemTypeStates: jest.fn().mockResolvedValue({
+        types: ['Bug', 'Requirement', 'Change Request', 'Task', 'User Story'],
+        states: ['New', 'Active', 'Resolved', 'Closed'],
+      }),
     };
 
     // Mock Git data provider
@@ -1181,6 +1186,49 @@ describe('ChangeDataFactory', () => {
         expect(hasChangesControl).toBe(false);
         expect(hasNonAssociated).toBe(false);
       });
+
+      it('should reject invalid workItemType values with a descriptive error (fail-fast validation)', async () => {
+        changeDataFactory['workItemFilterOptions'] = {
+          isEnabled: true,
+          workItemTypes: ['Bugg', 'Requirement'],
+          workItemStates: ['Closed'],
+        };
+
+        jest.spyOn(changeDataFactory, 'fetchChangesData').mockResolvedValue(undefined as any);
+
+        await expect(changeDataFactory.fetchSvdData()).rejects.toThrow(
+          /SVD work-item filter validation failed.*Bugg/
+        );
+      });
+
+      it('should reject invalid workItemState values with a descriptive error (fail-fast validation)', async () => {
+        changeDataFactory['workItemFilterOptions'] = {
+          isEnabled: true,
+          workItemTypes: ['Bug'],
+          workItemStates: ['Klozed'],
+        };
+
+        jest.spyOn(changeDataFactory, 'fetchChangesData').mockResolvedValue(undefined as any);
+
+        await expect(changeDataFactory.fetchSvdData()).rejects.toThrow(
+          /SVD work-item filter validation failed.*Klozed/
+        );
+      });
+
+      it('should accept capitalized-but-valid filter values without error (regression: PowerShell task case)', async () => {
+        changeDataFactory['workItemFilterOptions'] = {
+          isEnabled: true,
+          workItemTypes: ['Bug', 'Change Request'],
+          workItemStates: ['Closed', 'Resolved'],
+        };
+
+        jest.spyOn(changeDataFactory, 'fetchChangesData').mockImplementation(async () => {
+          changeDataFactory['rawChangesArray'] = [];
+        });
+
+        // Should not throw — capitalized values match the project metadata case-insensitively
+        await expect(changeDataFactory.fetchSvdData()).resolves.toBeUndefined();
+      });
     });
 
     describe('services.json helpers', () => {
@@ -1488,6 +1536,51 @@ describe('ChangeDataFactory', () => {
         expect(replacementSpy).toHaveBeenCalled();
         // Adapter is mocked, so we only assert that it returned whatever the mock provides
         expect(result).toBeDefined();
+      });
+
+      it('filterChangesByWorkItemOptions should match capitalized filter values (regression: zero results from PowerShell task)', () => {
+        const factory = changeDataFactory as any;
+        // PowerShell tasks typically send display-case strings like "Bug", "Closed"
+        factory.workItemFilterOptions = {
+          isEnabled: true,
+          workItemTypes: ['Bug', 'Change Request'],
+          workItemStates: ['Closed', 'Resolved'],
+        };
+
+        const changes = [
+          { workItem: { fields: { 'System.WorkItemType': 'Bug', 'System.State': 'Closed' } } },
+          { workItem: { fields: { 'System.WorkItemType': 'Change Request', 'System.State': 'Resolved' } } },
+          { workItem: { fields: { 'System.WorkItemType': 'Task', 'System.State': 'Active' } } },
+        ];
+
+        const result = factory.filterChangesByWorkItemOptions(changes);
+
+        // Bug/Closed and Change Request/Resolved must survive; Task/Active must be dropped
+        expect(result).toHaveLength(2);
+        expect(result[0].workItem.fields['System.WorkItemType']).toBe('Bug');
+        expect(result[1].workItem.fields['System.WorkItemType']).toBe('Change Request');
+      });
+
+      it('filterChangesByWorkItemOptions should drop changes whose type or state is not in the filter', () => {
+        const factory = changeDataFactory as any;
+        factory.workItemFilterOptions = {
+          isEnabled: true,
+          workItemTypes: ['requirement'],
+          workItemStates: ['closed'],
+        };
+
+        const changes = [
+          { workItem: { fields: { 'System.WorkItemType': 'Requirement', 'System.State': 'Closed' } } },
+          { workItem: { fields: { 'System.WorkItemType': 'Bug', 'System.State': 'Closed' } } },
+          { workItem: { fields: { 'System.WorkItemType': 'Requirement', 'System.State': 'Active' } } },
+        ];
+
+        const result = factory.filterChangesByWorkItemOptions(changes);
+
+        // Only Requirement+Closed survives
+        expect(result).toHaveLength(1);
+        expect(result[0].workItem.fields['System.WorkItemType']).toBe('Requirement');
+        expect(result[0].workItem.fields['System.State']).toBe('Closed');
       });
 
       it('changes adapter should keep only the latest commit per work item', async () => {


### PR DESCRIPTION
…alues

filterChangesByWorkItemOptions lowercased actual ADO field values but compared against raw filter arrays, so ["Bug"].includes("bug") → false and every change was dropped. PowerShell release tasks send display-case strings ("Bug", "Closed"); the frontend sends lowercase — causing the production misalignment between automatic and manual SVD generation.

Also adds fail-fast validation in fetchSvdData: when workItemFilterOptions is enabled, filter values are validated against project ADO metadata (GetWorkItemTypeStates) before any release/change gathering. Invalid values (e.g. typos) throw a descriptive error naming the bad value and listing valid options, instead of producing a silent zero-result doc.

5 regression tests added; 574/574 pass.