### PR TITLE
#297488 - per-side column metadata endpoint + trace table hyperlink fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.129.1",
       "license": "ISC",
       "dependencies": {
-        "@elisra-devops/docgen-data-provider": "^1.133.0",
-        "@elisra-devops/docgen-skins": "^0.24.0",
+        "@elisra-devops/docgen-data-provider": "^1.134.0",
+        "@elisra-devops/docgen-skins": "^0.25.0",
         "@types/html-minifier-terser": "^7.0.2",
         "axios": "^1.7.2",
         "cheerio": "^1.0.0",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@elisra-devops/docgen-data-provider": {
-      "version": "1.133.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.133.0.tgz",
-      "integrity": "sha512-1T4JyaO+59VyK7dKzZol/hgPgWpICuzE/MAr+gElhe01pT5qMWX8oCNkX5VUB674nDxaNxPkJkg5cwuJho7jww==",
+      "version": "1.134.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.134.0.tgz",
+      "integrity": "sha512-nxzglIqEqxR6B9ftogXMlWOq6Ua2ZmzsYI9c5edsZJpzZmni8KilQVIv65ChuKYeuqsBX/zwV9xrh/HGew6EDg==",
       "license": "ISC",
       "dependencies": {
         "@types/xml2js": "^0.4.5",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@elisra-devops/docgen-skins": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-skins/-/docgen-skins-0.24.0.tgz",
-      "integrity": "sha512-A2ThmqeuseEuDjHauL1JHFkb/ZE95A7UJ2ZHqW084ClxNzICaiac0NsWTwATRurIrk5Gpnk/uDY2yaBQMh6fdQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-skins/-/docgen-skins-0.25.0.tgz",
+      "integrity": "sha512-5VQxO09TxuQrz4ndSY/k+IW1BDDjFEMHnqXjmArB1VTkuluYXbedkPZNzsyuoGYvThavVPg2HuS3u9qghGuSng==",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^14.0.5",
@@ -7530,9 +7530,9 @@
       }
     },
     "@elisra-devops/docgen-data-provider": {
-      "version": "1.133.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.133.0.tgz",
-      "integrity": "sha512-1T4JyaO+59VyK7dKzZol/hgPgWpICuzE/MAr+gElhe01pT5qMWX8oCNkX5VUB674nDxaNxPkJkg5cwuJho7jww==",
+      "version": "1.134.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.134.0.tgz",
+      "integrity": "sha512-nxzglIqEqxR6B9ftogXMlWOq6Ua2ZmzsYI9c5edsZJpzZmni8KilQVIv65ChuKYeuqsBX/zwV9xrh/HGew6EDg==",
       "requires": {
         "@types/xml2js": "^0.4.5",
         "axios": "^1.7.2",
@@ -7554,9 +7554,9 @@
       }
     },
     "@elisra-devops/docgen-skins": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-skins/-/docgen-skins-0.24.0.tgz",
-      "integrity": "sha512-A2ThmqeuseEuDjHauL1JHFkb/ZE95A7UJ2ZHqW084ClxNzICaiac0NsWTwATRurIrk5Gpnk/uDY2yaBQMh6fdQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-skins/-/docgen-skins-0.25.0.tgz",
+      "integrity": "sha512-5VQxO09TxuQrz4ndSY/k+IW1BDDjFEMHnqXjmArB1VTkuluYXbedkPZNzsyuoGYvThavVPg2HuS3u9qghGuSng==",
       "requires": {
         "@types/node": "^14.0.5",
         "moment": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@elisra-devops/docgen-data-provider": "^1.133.0",
-    "@elisra-devops/docgen-skins": "^0.24.0",
+    "@elisra-devops/docgen-data-provider": "^1.134.0",
+    "@elisra-devops/docgen-skins": "^0.25.0",
     "@types/html-minifier-terser": "^7.0.2",
     "axios": "^1.7.2",
     "cheerio": "^1.0.0",

--- a/src/adapters/TraceByLinkedRequirementAdapter.ts
+++ b/src/adapters/TraceByLinkedRequirementAdapter.ts
@@ -11,10 +11,29 @@ export default class TraceByLinkedRequirementAdapter {
   includeCustomerId: boolean;
   private traceIdColumnWidth = '8.5%';
   private adoptedData: any[] = [];
+  private fieldDisplayMapping: Record<string, Record<string, string>>;
+  private fieldVisibility: Record<string, Record<string, boolean>>;
 
-  constructor(rawResults, queryMode = 'none') {
+  constructor(
+    rawResults,
+    queryMode = 'none',
+    fieldDisplayMapping: Record<string, Record<string, string>> = {},
+    fieldVisibility: Record<string, Record<string, boolean>> = {}
+  ) {
     this.rawMapping = rawResults;
     this.queryMode = queryMode;
+    this.fieldDisplayMapping = fieldDisplayMapping || {};
+    this.fieldVisibility = fieldVisibility || {};
+  }
+
+  private resolveDisplayName(defaultName: string, type: 'Requirement' | 'Test Case'): string {
+    // Linked mode has no referenceName — match by default display name as pseudo-key
+    const override = this.fieldDisplayMapping[type]?.[defaultName];
+    return typeof override === 'string' && override.trim() ? override.trim() : defaultName;
+  }
+
+  private isHidden(pseudoKey: string, type: 'Requirement' | 'Test Case'): boolean {
+    return this.fieldVisibility[type]?.[pseudoKey] === false;
   }
 
   adoptSkinData() {
@@ -58,6 +77,7 @@ export default class TraceByLinkedRequirementAdapter {
   ) {
     const requirementSource = JSON.parse(source);
     const hasCustomerId = requirementSource.customerId !== undefined;
+    const customerIdHidden = this.isHidden('Customer ID', 'Requirement');
 
     targets?.forEach((target) => {
       const tcTarget = JSON.parse(target);
@@ -69,9 +89,9 @@ export default class TraceByLinkedRequirementAdapter {
             width: this.traceIdColumnWidth,
             color: currentReqColor,
           },
-          { name: 'Title', value: requirementSource.title, color: currentReqColor },
-          hasCustomerId && {
-            name: 'Customer ID',
+          { name: this.resolveDisplayName('Title', 'Requirement'), value: requirementSource.title, color: currentReqColor },
+          hasCustomerId && !customerIdHidden && {
+            name: this.resolveDisplayName('Customer ID', 'Requirement'),
             value: requirementSource.customerId,
             color: currentReqColor,
           },
@@ -80,8 +100,9 @@ export default class TraceByLinkedRequirementAdapter {
             value: tcTarget.id,
             width: this.traceIdColumnWidth,
             color: currentTestColor,
+            sectionRefId: String(tcTarget.id),
           },
-          { name: 'Title', value: tcTarget.title, color: currentTestColor },
+          { name: this.resolveDisplayName('Title', 'Test Case'), value: tcTarget.title, color: currentTestColor },
         ],
         baseShading,
       });
@@ -102,6 +123,7 @@ export default class TraceByLinkedRequirementAdapter {
       const targetObj = JSON.parse(target);
       return targetObj.customerId !== undefined;
     });
+    const customerIdHidden = this.isHidden('Customer ID', 'Requirement');
     targets?.forEach((target) => {
       const reqTarget = JSON.parse(target);
       const fields = this.buildFields({
@@ -111,11 +133,12 @@ export default class TraceByLinkedRequirementAdapter {
             value: tcSource.id,
             width: this.traceIdColumnWidth,
             color: currentTestColor,
+            sectionRefId: String(tcSource.id),
           },
-          { name: 'Title', value: tcSource.title, color: currentTestColor },
+          { name: this.resolveDisplayName('Title', 'Test Case'), value: tcSource.title, color: currentTestColor },
           { name: 'Req ID', value: reqTarget.id, width: this.traceIdColumnWidth, color: currentReqColor },
-          { name: 'Title', value: reqTarget.title, color: currentReqColor },
-          hasCustomerId && { name: 'Customer ID', value: reqTarget.customerId, color: currentReqColor },
+          { name: this.resolveDisplayName('Title', 'Requirement'), value: reqTarget.title, color: currentReqColor },
+          hasCustomerId && !customerIdHidden && { name: this.resolveDisplayName('Customer ID', 'Requirement'), value: reqTarget.customerId, color: currentReqColor },
         ],
         baseShading,
       });

--- a/src/adapters/TraceQueryResultsSkinAdapter.ts
+++ b/src/adapters/TraceQueryResultsSkinAdapter.ts
@@ -6,6 +6,9 @@ import {
   calculateAdaptiveIdColumnWidth,
 } from '../utils/tablePresentation';
 
+// Columns that are always rendered — visibility toggle has no effect on them.
+const ALWAYS_VISIBLE_REFS = new Set(['System.Id', 'System.Title']);
+
 export default class TraceQueryResultsSkinAdapter {
   rawQueryMapping: any;
   queryMode: string;
@@ -15,12 +18,18 @@ export default class TraceQueryResultsSkinAdapter {
   private includeCommonColumnsMode: string;
   private traceIdColumnWidth = '8.5%';
   private adoptedData: any[] = [];
+  private fieldDisplayMapping: Record<string, Record<string, string>>;
+  private fieldVisibility: Record<string, Record<string, boolean>>;
+  private fieldOrder: Record<string, string[]>;
 
   constructor(
     rawResults,
     queryMode = 'none',
     includeCustomerId = false,
-    includeCommonColumns: string = 'both'
+    includeCommonColumns: string = 'both',
+    fieldDisplayMapping: Record<string, Record<string, string>> = {},
+    fieldVisibility: Record<string, Record<string, boolean>> = {},
+    fieldOrder: Record<string, string[]> = {}
   ) {
     const { sourceTargetsMap, sortingSourceColumnsMap, sortingTargetsColumnsMap } = rawResults;
     this.rawQueryMapping = sourceTargetsMap;
@@ -29,6 +38,21 @@ export default class TraceQueryResultsSkinAdapter {
     this.queryMode = queryMode;
     this.includeCustomerId = includeCustomerId;
     this.includeCommonColumnsMode = includeCommonColumns;
+    this.fieldDisplayMapping = fieldDisplayMapping || {};
+    this.fieldVisibility = fieldVisibility || {};
+    this.fieldOrder = fieldOrder || {};
+  }
+
+  private resolveDisplayName(defaultName: string, referenceName: string, type: string): string {
+    const typeKey = type === 'Req' ? 'Requirement' : type;
+    const override = this.fieldDisplayMapping[typeKey]?.[referenceName];
+    return typeof override === 'string' && override.trim() ? override.trim() : defaultName;
+  }
+
+  private isHidden(referenceName: string, type: string): boolean {
+    if (ALWAYS_VISIBLE_REFS.has(referenceName)) return false;
+    const typeKey = type === 'Req' ? 'Requirement' : type;
+    return this.fieldVisibility[typeKey]?.[referenceName] === false;
   }
 
   adoptSkinData() {
@@ -76,26 +100,40 @@ export default class TraceQueryResultsSkinAdapter {
     const mapToUse: Map<string, string> = !isSource
       ? this.sortingTargetsColumnsMap
       : this.sortingSourceColumnsMap;
-    // Process 'Title' field first if it exists
-    const titleReferenceName = Array.from(mapToUse.entries()).find(
-      ([_, fieldName]) => fieldName === 'Title'
-    )?.[0];
+
+    // Detect Title by stable referenceName (value may be 'Title' or 'System.Title' depending on
+    // whether System.Title was an explicitly selected query column or only force-included).
+    const TITLE_REF = 'System.Title';
+    const titleReferenceName = mapToUse.has(TITLE_REF) ? TITLE_REF : undefined;
 
     if (item && titleReferenceName && item.fields[titleReferenceName] !== undefined) {
       adaptedFields.push({
-        name: `${type} Title`,
+        name: this.resolveDisplayName(`${type} Title`, titleReferenceName, type),
         value: item.fields[titleReferenceName],
         color: color,
       });
     }
 
-    // Process other fields
-    for (const [referenceName, fieldName] of mapToUse.entries()) {
+    // Process other fields — sorted by user-defined column order when present
+    const typeKey = type === 'Req' ? 'Requirement' : type;
+    const orderList = this.fieldOrder?.[typeKey] || [];
+    const allEntries = [...mapToUse.entries()].filter(([ref, fn]) => {
+      const dn = normalizeFieldName(fn);
+      return ref !== TITLE_REF && dn !== 'Work Item Type' && dn !== 'ID';
+    });
+    if (orderList.length > 0) {
+      allEntries.sort(([refA], [refB]) => {
+        const ia = orderList.indexOf(refA);
+        const ib = orderList.indexOf(refB);
+        if (ia === -1 && ib === -1) return 0;
+        if (ia === -1) return 1;
+        if (ib === -1) return -1;
+        return ia - ib;
+      });
+    }
+
+    for (const [referenceName, fieldName] of allEntries) {
       const displayName = normalizeFieldName(fieldName);
-      // Skip 'Title' and 'Work Item Type'; never include ID as a regular column
-      if (displayName === 'Title' || displayName === 'Work Item Type' || displayName === 'ID') {
-        continue;
-      }
       // Skip common columns if only one instance is allowed
       if (
         excludeCommonColumnInstance &&
@@ -105,11 +143,18 @@ export default class TraceQueryResultsSkinAdapter {
       ) {
         continue;
       }
+      // Skip user-hidden columns
+      if (this.isHidden(referenceName, type)) {
+        continue;
+      }
+
+      // Compute the final header: use user override if set, else the default display name
+      const resolvedName = (defaultName: string) => this.resolveDisplayName(defaultName, referenceName, type);
 
       switch (displayName) {
         case 'Priority': {
           adaptedFields.push({
-            name: displayName,
+            name: resolvedName(displayName),
             value: item?.fields[referenceName] || '',
             width: '6.5%',
             color: color,
@@ -118,14 +163,14 @@ export default class TraceQueryResultsSkinAdapter {
         }
         case 'Assigned To':
           adaptedFields.push({
-            name: displayName,
+            name: resolvedName(displayName),
             value: item?.fields[referenceName]?.displayName || '',
             color: color,
           });
           break;
         case 'Customer ID':
           adaptedFields.push({
-            name: displayName,
+            name: resolvedName(displayName),
             value: item?.fields[referenceName] || '',
             color: color,
             width: '9.7%',
@@ -134,7 +179,7 @@ export default class TraceQueryResultsSkinAdapter {
           break;
         case 'Area Path':
           adaptedFields.push({
-            name: 'Node Name',
+            name: resolvedName('Node Name'),
             value: this.convertAreaPathToNodeName(item?.fields[referenceName] || ''),
             color: color,
             width: '18%',
@@ -142,7 +187,7 @@ export default class TraceQueryResultsSkinAdapter {
           break;
         default:
           adaptedFields.push({
-            name: displayName,
+            name: resolvedName(displayName),
             value:
               typeof item?.fields[referenceName] === 'object'
                 ? item?.fields[referenceName]?.displayName || ''
@@ -168,7 +213,7 @@ export default class TraceQueryResultsSkinAdapter {
     const adaptedSourceFields: any[] = this.adaptFields(
       source,
       currentReqColor,
-      false,
+      true,
       'Req',
       this.includeCommonColumnsMode === 'testOnly'
     );
@@ -185,8 +230,8 @@ export default class TraceQueryResultsSkinAdapter {
         items: [
           { name: 'Req ID', value: source.id, width: this.traceIdColumnWidth, color: currentReqColor },
           ...adaptedSourceFields,
-          { name: 'Test Case ID', value: '', width: this.traceIdColumnWidth, color: currentTestColor },
-          { name: 'Test Case Title', value: '', color: currentTestColor },
+          { name: 'Test Case ID', value: '', width: this.traceIdColumnWidth, color: currentTestColor, sectionRefId: undefined, url: undefined },
+          { name: this.resolveDisplayName('Test Case Title', 'System.Title', 'Test Case'), value: '', color: currentTestColor },
           ...adaptedTargetFields,
         ],
         baseShading,
@@ -205,7 +250,7 @@ export default class TraceQueryResultsSkinAdapter {
           items: [
             { name: 'Req ID', value: source.id, width: this.traceIdColumnWidth, color: currentReqColor },
             ...adaptedSourceFields,
-            { name: 'Test Case ID', value: target.id, width: this.traceIdColumnWidth, color: currentTestColor },
+            { name: 'Test Case ID', value: target.id, width: this.traceIdColumnWidth, color: currentTestColor, sectionRefId: String(target.id) },
             ...adaptedTargetFields,
           ],
           baseShading,
@@ -239,10 +284,10 @@ export default class TraceQueryResultsSkinAdapter {
       );
       const fields = this.buildFields({
         items: [
-          { name: 'Test Case ID', value: source.id, width: this.traceIdColumnWidth, color: currentTestColor },
+          { name: 'Test Case ID', value: source.id, width: this.traceIdColumnWidth, color: currentTestColor, sectionRefId: String(source.id) },
           ...adaptedSourceFields,
           { name: 'Req ID', value: '', width: this.traceIdColumnWidth, color: currentReqColor },
-          { name: 'Req Title', value: '', color: currentReqColor },
+          { name: this.resolveDisplayName('Req Title', 'System.Title', 'Req'), value: '', color: currentReqColor },
           ...adaptedTargetFields,
         ],
         baseShading,
@@ -259,7 +304,7 @@ export default class TraceQueryResultsSkinAdapter {
         );
         const fields = this.buildFields({
           items: [
-            { name: 'Test Case ID', value: source.id, width: this.traceIdColumnWidth, color: currentTestColor },
+            { name: 'Test Case ID', value: source.id, width: this.traceIdColumnWidth, color: currentTestColor, sectionRefId: String(source.id) },
             ...adaptedSourceFields,
             { name: 'Req ID', value: target.id, width: this.traceIdColumnWidth, color: currentReqColor },
             ...adaptedTargetFields,

--- a/src/factories/TestDataFactory.ts
+++ b/src/factories/TestDataFactory.ts
@@ -412,7 +412,7 @@ export default class TestDataFactory {
           for (const { mapData, type, adoptedDataKey } of linkedRequirementConfigs) {
             const title = this.buildTraceTitle(type);
             if (mapData) {
-              const linkedRequirementTraceSkinAdapter = new TraceByLinkedRequirementAdapter(mapData, type);
+              const linkedRequirementTraceSkinAdapter = new TraceByLinkedRequirementAdapter(mapData, type, this.traceAnalysisRequest?.fieldDisplayMapping, this.traceAnalysisRequest?.fieldVisibility);
 
               linkedRequirementTraceSkinAdapter.adoptSkinData();
               const adoptedData = linkedRequirementTraceSkinAdapter.getAdoptedData();
@@ -446,7 +446,10 @@ export default class TestDataFactory {
                 queryResults,
                 type,
                 this.includeCustomerId,
-                includeCommonColumnsMode
+                includeCommonColumnsMode,
+                this.traceAnalysisRequest?.fieldDisplayMapping,
+                this.traceAnalysisRequest?.fieldVisibility,
+                this.traceAnalysisRequest?.fieldOrder
               );
 
               queryResultSkinAdapter.adoptSkinData();
@@ -790,6 +793,7 @@ export default class TestDataFactory {
                       })
                     );
                     let adoptedTestCaseData = {
+                      id: testCase.id,
                       testCaseHeaderSkinData,
                       testCaseStepsSkinData,
                       testCaseAttachments,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -653,6 +653,20 @@ export class Routes {
       }
     });
 
+    app.route('/azure/trace/columns').post(async (req: Request, res: Response) => {
+      try {
+        const { body } = req;
+        const { reqTestQuery, testReqQuery, teamProject = '' } = body || {};
+        const svc = getAzureService(body);
+        const data = await svc.getTraceColumns(reqTestQuery, testReqQuery, teamProject);
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        const msg = error?.message ?? String(error);
+        logger.error(`azure/trace/columns error: ${msg}`);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: msg });
+      }
+    });
+
     app.route('/azure/queries/:queryId/historical-results').post(async (req: Request, res: Response) => {
       try {
         const { body, params } = req;

--- a/src/services/AzureDataService.ts
+++ b/src/services/AzureDataService.ts
@@ -44,6 +44,15 @@ export default class AzureDataService {
     return tickets.GetQueryResultById(queryId, teamProjectId);
   }
 
+  async getTraceColumns(reqTestQuery: any, testReqQuery: any, teamProject: string) {
+    const tickets = await this.dg.getTicketsDataProvider();
+    return tickets.GetTraceColumnsByType(
+      reqTestQuery?.wiql?.href,
+      testReqQuery?.wiql?.href,
+      teamProject,
+    );
+  }
+
   async getHistoricalQueries(teamProjectId = '', path = 'shared') {
     const tickets = await this.dg.getTicketsDataProvider();
     return tickets.GetHistoricalQueries(teamProjectId, path);

--- a/src/test/adapters-test/TraceByLinkedRequirementAdapter.test.ts
+++ b/src/test/adapters-test/TraceByLinkedRequirementAdapter.test.ts
@@ -81,6 +81,75 @@ describe('TraceByLinkedRequirementAdapter', () => {
     expect((logger as any).error).toHaveBeenCalled();
   });
 
+  describe('fieldDisplayMapping overrides', () => {
+    test('overrides Requirement Title in req-test mode', () => {
+      const req = makeReqJson({ customerId: 'C-1' });
+      const tc = makeTcJson();
+      const map = new Map<string, string[]>([[req, [tc]]]);
+
+      const fieldDisplayMapping = {
+        Requirement: { Title: 'Req Name' },
+      };
+
+      const adapter = new TraceByLinkedRequirementAdapter(map, 'req-test', fieldDisplayMapping);
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+
+      expect(fields.find((f: any) => f.name === 'Req Name')).toBeDefined();
+      expect(fields.find((f: any) => f.name === 'Req Name').value).toBe('Req 1');
+    });
+
+    test('overrides Customer ID for Requirement side', () => {
+      const req = makeReqJson({ customerId: 'C-1' });
+      const tc = makeTcJson();
+      const map = new Map<string, string[]>([[req, [tc]]]);
+
+      const fieldDisplayMapping = {
+        Requirement: { 'Customer ID': 'System ID' },
+      };
+
+      const adapter = new TraceByLinkedRequirementAdapter(map, 'req-test', fieldDisplayMapping);
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+
+      const systemIdField = fields.find((f: any) => f.name === 'System ID');
+      expect(systemIdField).toBeDefined();
+      expect(systemIdField.value).toBe('C-1');
+      expect(fields.find((f: any) => f.name === 'Customer ID')).toBeUndefined();
+    });
+
+    test('overrides Test Case Title in test-req mode', () => {
+      const tc = makeTcJson();
+      const req = makeReqJson({ id: 2, customerId: undefined });
+      const map = new Map<string, string[]>([[tc, [req]]]);
+
+      const fieldDisplayMapping = {
+        'Test Case': { Title: 'TC Description' },
+      };
+
+      const adapter = new TraceByLinkedRequirementAdapter(map, 'test-req', fieldDisplayMapping);
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+
+      expect(fields.find((f: any) => f.name === 'TC Description')).toBeDefined();
+      expect(fields.find((f: any) => f.name === 'TC Description').value).toBe('TC 10');
+    });
+
+    test('no mapping defaults to original names', () => {
+      const req = makeReqJson();
+      const tc = makeTcJson();
+      const map = new Map<string, string[]>([[req, [tc]]]);
+
+      const adapter = new TraceByLinkedRequirementAdapter(map, 'req-test');
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+
+      // Title fields should exist with default names
+      const titleFields = fields.filter((f: any) => f.name === 'Title');
+      expect(titleFields.length).toBe(2); // one for Req, one for TC
+    });
+  });
+
   test('adapts Req/Test Case ID column widths when IDs are long', () => {
     const req = makeReqJson({ id: 123456789012 });
     const tc = makeTcJson({ id: 987654321098 });

--- a/src/test/adapters-test/TraceQueryResultsSkinAdapter.test.ts
+++ b/src/test/adapters-test/TraceQueryResultsSkinAdapter.test.ts
@@ -220,6 +220,147 @@ describe('TraceQueryResultsSkinAdapter', () => {
     expect((logger as any).error).toHaveBeenCalled();
   });
 
+  describe('fieldDisplayMapping overrides', () => {
+    test('overrides column header by referenceName for Requirement side', () => {
+      const { sortingSourceColumnsMap, sortingTargetsColumnsMap } = makeMaps();
+      const req = makeItem(1, {
+        'System.Title': 'Req 1',
+        'Custom.CustomerId': 'C1',
+      });
+      const tc = makeItem(2, { 'System.Title': 'TC 1' });
+      const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
+
+      const fieldDisplayMapping = {
+        Requirement: { 'Custom.CustomerId': 'System ID' },
+      };
+
+      const adapter = new TraceQueryResultsSkinAdapter(
+        { sourceTargetsMap, sortingSourceColumnsMap, sortingTargetsColumnsMap },
+        'req-test',
+        true,
+        'both',
+        fieldDisplayMapping
+      );
+
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+
+      const systemIdField = fields.find((f: any) => f.name === 'System ID');
+      expect(systemIdField).toBeDefined();
+      expect(systemIdField.value).toBe('C1');
+    });
+
+    test('overrides Area Path→Node Name with user mapping', () => {
+      const { sortingSourceColumnsMap, sortingTargetsColumnsMap } = makeMaps();
+      const req = makeItem(1, {
+        'System.Title': 'Req 1',
+        'System.AreaPath': 'Root\\Sub',
+      });
+      const tc = makeItem(2, { 'System.Title': 'TC 1' });
+      const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
+
+      const fieldDisplayMapping = {
+        Requirement: { 'System.AreaPath': 'Department' },
+      };
+
+      const adapter = new TraceQueryResultsSkinAdapter(
+        { sourceTargetsMap, sortingSourceColumnsMap, sortingTargetsColumnsMap },
+        'req-test',
+        false,
+        'both',
+        fieldDisplayMapping
+      );
+
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+
+      const deptField = fields.find((f: any) => f.name === 'Department');
+      expect(deptField).toBeDefined();
+      expect(deptField.value).toBe('Sub');
+    });
+
+    test('empty override value leaves default name', () => {
+      const { sortingSourceColumnsMap, sortingTargetsColumnsMap } = makeMaps();
+      const req = makeItem(1, {
+        'System.Title': 'Req 1',
+        'Custom.CustomerId': 'C1',
+      });
+      const tc = makeItem(2, { 'System.Title': 'TC 1' });
+      const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
+
+      const fieldDisplayMapping = {
+        Requirement: { 'Custom.CustomerId': '   ' },
+      };
+
+      const adapter = new TraceQueryResultsSkinAdapter(
+        { sourceTargetsMap, sortingSourceColumnsMap, sortingTargetsColumnsMap },
+        'req-test',
+        true,
+        'both',
+        fieldDisplayMapping
+      );
+
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+
+      expect(fields.find((f: any) => f.name === 'Customer ID')).toBeDefined();
+    });
+
+    test('no mapping (undefined) works same as no override', () => {
+      const { sortingSourceColumnsMap, sortingTargetsColumnsMap } = makeMaps();
+      const req = makeItem(1, { 'System.Title': 'Req 1' });
+      const tc = makeItem(2, { 'System.Title': 'TC 1' });
+      const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
+
+      const adapter = new TraceQueryResultsSkinAdapter(
+        { sourceTargetsMap, sortingSourceColumnsMap, sortingTargetsColumnsMap },
+        'req-test',
+        false,
+        'both'
+      );
+
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+      expect(fields.find((f: any) => f.name === 'Req Title')).toBeDefined();
+    });
+
+    test('Test Case side override is independent of Requirement side', () => {
+      const { sortingSourceColumnsMap, sortingTargetsColumnsMap } = makeMaps();
+      const req = makeItem(1, {
+        'System.Title': 'Req 1',
+        'Microsoft.VSTS.Common.Priority': 1,
+      });
+      const tc = makeItem(2, {
+        'System.Title': 'TC 1',
+        'Microsoft.VSTS.Common.Priority': 2,
+      });
+      const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
+
+      const fieldDisplayMapping = {
+        'Test Case': { 'Microsoft.VSTS.Common.Priority': 'Urgency' },
+      };
+
+      const adapter = new TraceQueryResultsSkinAdapter(
+        { sourceTargetsMap, sortingSourceColumnsMap, sortingTargetsColumnsMap },
+        'req-test',
+        false,
+        'both',
+        fieldDisplayMapping
+      );
+
+      adapter.adoptSkinData();
+      const fields = adapter.getAdoptedData()[0].fields;
+
+      // Req side: Priority stays as-is
+      const reqPriority = fields.find((f: any) => f.name === 'Priority');
+      expect(reqPriority).toBeDefined();
+      // TC side: Priority overridden to Urgency
+      const tcUrgency = fields.find((f: any) => f.name === 'Urgency');
+      expect(tcUrgency).toBeDefined();
+      expect(tcUrgency.value).toBe(2);
+    });
+  });
+
   test('adapts Req/Test Case ID column widths when IDs are long', () => {
     const { sortingSourceColumnsMap, sortingTargetsColumnsMap } = makeMaps();
     const req = makeItem(123456789012, { 'System.Title': 'Req long' });

--- a/src/test/services-test/AzureDataService.test.ts
+++ b/src/test/services-test/AzureDataService.test.ts
@@ -111,3 +111,51 @@ describe('AzureDataService historical query methods', () => {
     expect(result).toEqual({ value: [{ id: 1 }] });
   });
 });
+
+describe('AzureDataService.getTraceColumns', () => {
+  const ticketsProvider = {
+    GetTraceColumnsByType: jest.fn(),
+  };
+
+  const getTicketsDataProviderMock = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getTicketsDataProviderMock.mockResolvedValue(ticketsProvider);
+  });
+
+  it('delegates to GetTraceColumnsByType with correct wiql hrefs', async () => {
+    const expected = { Requirement: [{ referenceName: 'Custom.Foo', name: 'Foo' }], 'Test Case': [] };
+    ticketsProvider.GetTraceColumnsByType.mockResolvedValueOnce(expected);
+
+    const svc = new AzureDataService('https://org/', 'pat');
+    // Inject mock provider
+    (svc as any).dg = { getTicketsDataProvider: getTicketsDataProviderMock };
+
+    const reqTestQuery = { wiql: { href: 'https://ado/wiql/rt' } };
+    const testReqQuery = { wiql: { href: 'https://ado/wiql/tr' } };
+    const result = await svc.getTraceColumns(reqTestQuery, testReqQuery, 'my-project');
+
+    expect(ticketsProvider.GetTraceColumnsByType).toHaveBeenCalledWith(
+      'https://ado/wiql/rt',
+      'https://ado/wiql/tr',
+      'my-project',
+    );
+    expect(result).toEqual(expected);
+  });
+
+  it('passes undefined hrefs when queries are null', async () => {
+    ticketsProvider.GetTraceColumnsByType.mockResolvedValueOnce({ Requirement: [], 'Test Case': [] });
+
+    const svc = new AzureDataService('https://org/', 'pat');
+    (svc as any).dg = { getTicketsDataProvider: getTicketsDataProviderMock };
+
+    await svc.getTraceColumns(null, null, 'my-project');
+
+    expect(ticketsProvider.GetTraceColumnsByType).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      'my-project',
+    );
+  });
+});


### PR DESCRIPTION
- Add POST /azure/trace/columns route delegating to GetTraceColumnsByType
- Add getTraceColumns to AzureDataService
- TraceQueryResultsSkinAdapter: respect per-side field visibility, display name overrides, and column order; remove ADO URL fallback from Test Case ID cells (in-document links only)
- Tests added for TraceQueryResultsSkinAdapter, TraceByLinkedRequirementAdapter, and AzureDataService.getTraceColumns