### PR TITLE
#297488 - upgrade field map to 3-level nested structure + query defin…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.129.2",
       "license": "ISC",
       "dependencies": {
-        "@elisra-devops/docgen-data-provider": "^1.134.0",
+        "@elisra-devops/docgen-data-provider": "^1.135.0",
         "@elisra-devops/docgen-skins": "^0.25.0",
         "@types/html-minifier-terser": "^7.0.2",
         "axios": "^1.7.2",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@elisra-devops/docgen-data-provider": {
-      "version": "1.134.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.134.0.tgz",
-      "integrity": "sha512-nxzglIqEqxR6B9ftogXMlWOq6Ua2ZmzsYI9c5edsZJpzZmni8KilQVIv65ChuKYeuqsBX/zwV9xrh/HGew6EDg==",
+      "version": "1.135.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.135.0.tgz",
+      "integrity": "sha512-jGkCeUUzXAeJ/2uOdYGOq6zJiM3l9rLAwV6mdnXRAcdHBCLUWD6DBGO0oumVrmInC5KlGGb8DT7kpwXrhz/ZtQ==",
       "license": "ISC",
       "dependencies": {
         "@types/xml2js": "^0.4.5",
@@ -7530,9 +7530,9 @@
       }
     },
     "@elisra-devops/docgen-data-provider": {
-      "version": "1.134.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.134.0.tgz",
-      "integrity": "sha512-nxzglIqEqxR6B9ftogXMlWOq6Ua2ZmzsYI9c5edsZJpzZmni8KilQVIv65ChuKYeuqsBX/zwV9xrh/HGew6EDg==",
+      "version": "1.135.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.135.0.tgz",
+      "integrity": "sha512-jGkCeUUzXAeJ/2uOdYGOq6zJiM3l9rLAwV6mdnXRAcdHBCLUWD6DBGO0oumVrmInC5KlGGb8DT7kpwXrhz/ZtQ==",
       "requires": {
         "@types/xml2js": "^0.4.5",
         "axios": "^1.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.129.2",
       "license": "ISC",
       "dependencies": {
-        "@elisra-devops/docgen-data-provider": "^1.135.0",
+        "@elisra-devops/docgen-data-provider": "^1.136.0",
         "@elisra-devops/docgen-skins": "^0.25.0",
         "@types/html-minifier-terser": "^7.0.2",
         "axios": "^1.7.2",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@elisra-devops/docgen-data-provider": {
-      "version": "1.135.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.135.0.tgz",
-      "integrity": "sha512-jGkCeUUzXAeJ/2uOdYGOq6zJiM3l9rLAwV6mdnXRAcdHBCLUWD6DBGO0oumVrmInC5KlGGb8DT7kpwXrhz/ZtQ==",
+      "version": "1.136.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.136.0.tgz",
+      "integrity": "sha512-4jtiXqciEoZKSHUfNQqxom6K9w+v9jQZItPKpgz75kS0rYR7oRpzlPIK6f6hW98Irb/b+VSwKVsbbex3m94LLQ==",
       "license": "ISC",
       "dependencies": {
         "@types/xml2js": "^0.4.5",
@@ -7530,9 +7530,9 @@
       }
     },
     "@elisra-devops/docgen-data-provider": {
-      "version": "1.135.0",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.135.0.tgz",
-      "integrity": "sha512-jGkCeUUzXAeJ/2uOdYGOq6zJiM3l9rLAwV6mdnXRAcdHBCLUWD6DBGO0oumVrmInC5KlGGb8DT7kpwXrhz/ZtQ==",
+      "version": "1.136.0",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.136.0.tgz",
+      "integrity": "sha512-4jtiXqciEoZKSHUfNQqxom6K9w+v9jQZItPKpgz75kS0rYR7oRpzlPIK6f6hW98Irb/b+VSwKVsbbex3m94LLQ==",
       "requires": {
         "@types/xml2js": "^0.4.5",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@elisra-devops/docgen-data-provider": "^1.135.0",
+    "@elisra-devops/docgen-data-provider": "^1.136.0",
     "@elisra-devops/docgen-skins": "^0.25.0",
     "@types/html-minifier-terser": "^7.0.2",
     "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@elisra-devops/docgen-data-provider": "^1.134.0",
+    "@elisra-devops/docgen-data-provider": "^1.135.0",
     "@elisra-devops/docgen-skins": "^0.25.0",
     "@types/html-minifier-terser": "^7.0.2",
     "axios": "^1.7.2",

--- a/src/adapters/TraceQueryResultsSkinAdapter.ts
+++ b/src/adapters/TraceQueryResultsSkinAdapter.ts
@@ -18,18 +18,18 @@ export default class TraceQueryResultsSkinAdapter {
   private includeCommonColumnsMode: string;
   private traceIdColumnWidth = '8.5%';
   private adoptedData: any[] = [];
-  private fieldDisplayMapping: Record<string, Record<string, string>>;
-  private fieldVisibility: Record<string, Record<string, boolean>>;
-  private fieldOrder: Record<string, string[]>;
+  private fieldDisplayMapping: Record<string, Record<string, Record<string, string>>>;
+  private fieldVisibility: Record<string, Record<string, Record<string, boolean>>>;
+  private fieldOrder: Record<string, Record<string, string[]>>;
 
   constructor(
     rawResults,
     queryMode = 'none',
     includeCustomerId = false,
     includeCommonColumns: string = 'both',
-    fieldDisplayMapping: Record<string, Record<string, string>> = {},
-    fieldVisibility: Record<string, Record<string, boolean>> = {},
-    fieldOrder: Record<string, string[]> = {}
+    fieldDisplayMapping: Record<string, Record<string, Record<string, string>>> = {},
+    fieldVisibility: Record<string, Record<string, Record<string, boolean>>> = {},
+    fieldOrder: Record<string, Record<string, string[]>> = {}
   ) {
     const { sourceTargetsMap, sortingSourceColumnsMap, sortingTargetsColumnsMap } = rawResults;
     this.rawQueryMapping = sourceTargetsMap;
@@ -45,14 +45,14 @@ export default class TraceQueryResultsSkinAdapter {
 
   private resolveDisplayName(defaultName: string, referenceName: string, type: string): string {
     const typeKey = type === 'Req' ? 'Requirement' : type;
-    const override = this.fieldDisplayMapping[typeKey]?.[referenceName];
+    const override = this.fieldDisplayMapping[this.queryMode]?.[typeKey]?.[referenceName];
     return typeof override === 'string' && override.trim() ? override.trim() : defaultName;
   }
 
   private isHidden(referenceName: string, type: string): boolean {
     if (ALWAYS_VISIBLE_REFS.has(referenceName)) return false;
     const typeKey = type === 'Req' ? 'Requirement' : type;
-    return this.fieldVisibility[typeKey]?.[referenceName] === false;
+    return this.fieldVisibility[this.queryMode]?.[typeKey]?.[referenceName] === false;
   }
 
   adoptSkinData() {
@@ -116,7 +116,7 @@ export default class TraceQueryResultsSkinAdapter {
 
     // Process other fields — sorted by user-defined column order when present
     const typeKey = type === 'Req' ? 'Requirement' : type;
-    const orderList = this.fieldOrder?.[typeKey] || [];
+    const orderList = this.fieldOrder?.[this.queryMode]?.[typeKey] || [];
     const allEntries = [...mapToUse.entries()].filter(([ref, fn]) => {
       const dn = normalizeFieldName(fn);
       return ref !== TITLE_REF && dn !== 'Work Item Type' && dn !== 'ID';

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -653,6 +653,20 @@ export class Routes {
       }
     });
 
+    app.route('/azure/queries/:queryId/definition').post(async (req: Request, res: Response) => {
+      try {
+        const { body, params } = req;
+        const { teamProjectId = '' } = body || {};
+        const queryId = params.queryId;
+        const svc = getAzureService(body);
+        const data = await svc.getQueryDefinition(queryId, teamProjectId);
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        logger.error(`azure/queries/:queryId/definition error: ${error.message}`);
+        res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ message: error.message });
+      }
+    });
+
     app.route('/azure/trace/columns').post(async (req: Request, res: Response) => {
       try {
         const { body } = req;

--- a/src/services/AzureDataService.ts
+++ b/src/services/AzureDataService.ts
@@ -44,6 +44,11 @@ export default class AzureDataService {
     return tickets.GetQueryResultById(queryId, teamProjectId);
   }
 
+  async getQueryDefinition(queryId: string, teamProjectId = '') {
+    const tickets = await this.dg.getTicketsDataProvider();
+    return tickets.GetQueryDefinitionById(queryId, teamProjectId);
+  }
+
   async getTraceColumns(reqTestQuery: any, testReqQuery: any, teamProject: string) {
     const tickets = await this.dg.getTicketsDataProvider();
     return tickets.GetTraceColumnsByType(

--- a/src/test/adapters-test/TraceQueryResultsSkinAdapter.test.ts
+++ b/src/test/adapters-test/TraceQueryResultsSkinAdapter.test.ts
@@ -231,7 +231,7 @@ describe('TraceQueryResultsSkinAdapter', () => {
       const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
 
       const fieldDisplayMapping = {
-        Requirement: { 'Custom.CustomerId': 'System ID' },
+        'req-test': { Requirement: { 'Custom.CustomerId': 'System ID' } },
       };
 
       const adapter = new TraceQueryResultsSkinAdapter(
@@ -260,7 +260,7 @@ describe('TraceQueryResultsSkinAdapter', () => {
       const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
 
       const fieldDisplayMapping = {
-        Requirement: { 'System.AreaPath': 'Department' },
+        'req-test': { Requirement: { 'System.AreaPath': 'Department' } },
       };
 
       const adapter = new TraceQueryResultsSkinAdapter(
@@ -289,7 +289,7 @@ describe('TraceQueryResultsSkinAdapter', () => {
       const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
 
       const fieldDisplayMapping = {
-        Requirement: { 'Custom.CustomerId': '   ' },
+        'req-test': { Requirement: { 'Custom.CustomerId': '   ' } },
       };
 
       const adapter = new TraceQueryResultsSkinAdapter(
@@ -337,7 +337,7 @@ describe('TraceQueryResultsSkinAdapter', () => {
       const sourceTargetsMap = new Map<any, any[]>([[req, [tc]]]);
 
       const fieldDisplayMapping = {
-        'Test Case': { 'Microsoft.VSTS.Common.Priority': 'Urgency' },
+        'req-test': { 'Test Case': { 'Microsoft.VSTS.Common.Priority': 'Urgency' } },
       };
 
       const adapter = new TraceQueryResultsSkinAdapter(


### PR DESCRIPTION
…ition route

  TraceQueryResultsSkinAdapter: update fieldDisplayMapping, fieldVisibility,
  fieldOrder types from Record<typeKey, ...> to Record<queryKey, Record<typeKey, ...>>.
  All lookups now key by queryMode first (getOverrideName, isHidden, getOrder).

  AzureDataService: add getQueryDefinition forwarding to data-provider.
  routes/index.ts: add POST /azure/queries/:queryId/definition endpoint.

  Tests: update fixtures to 3-level shape (req-test wrapper around type keys).