### PR TITLE
fix(svd): resolve release id correctly for filename and release-compo…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.130.1",
       "license": "ISC",
       "dependencies": {
-        "@elisra-devops/docgen-data-provider": "^1.136.5",
+        "@elisra-devops/docgen-data-provider": "^1.136.6",
         "@elisra-devops/docgen-skins": "^0.26.0",
         "@types/html-minifier-terser": "^7.0.2",
         "axios": "^1.7.2",
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@elisra-devops/docgen-data-provider": {
-      "version": "1.136.5",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.136.5.tgz",
-      "integrity": "sha512-uvtGRTwPG2Jrk+/6ihhnUteedDVjufwJwYojVeYQMJByoZzqxtU+jZrcaIGLrZ27a9H0euLy8+/ujpxtZiTeXA==",
+      "version": "1.136.6",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.136.6.tgz",
+      "integrity": "sha512-dRnJva1LJ1rqITiRGS04HdTmw4SzfES4KHs9YNA759SHSyWD/kuFpbA+/jjex7Jp4c1MvXKCmfGHf3Xsd26Yrg==",
       "license": "ISC",
       "dependencies": {
         "@types/xml2js": "^0.4.5",
@@ -7530,9 +7530,9 @@
       }
     },
     "@elisra-devops/docgen-data-provider": {
-      "version": "1.136.5",
-      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.136.5.tgz",
-      "integrity": "sha512-uvtGRTwPG2Jrk+/6ihhnUteedDVjufwJwYojVeYQMJByoZzqxtU+jZrcaIGLrZ27a9H0euLy8+/ujpxtZiTeXA==",
+      "version": "1.136.6",
+      "resolved": "https://registry.npmjs.org/@elisra-devops/docgen-data-provider/-/docgen-data-provider-1.136.6.tgz",
+      "integrity": "sha512-dRnJva1LJ1rqITiRGS04HdTmw4SzfES4KHs9YNA759SHSyWD/kuFpbA+/jjex7Jp4c1MvXKCmfGHf3Xsd26Yrg==",
       "requires": {
         "@types/xml2js": "^0.4.5",
         "axios": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@elisra-devops/docgen-data-provider": "^1.136.5",
+    "@elisra-devops/docgen-data-provider": "^1.136.6",
     "@elisra-devops/docgen-skins": "^0.26.0",
     "@types/html-minifier-terser": "^7.0.2",
     "axios": "^1.7.2",

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -2046,6 +2046,7 @@ export default class DgContentControls {
     baselineOptions: any = undefined,
   ) {
     let adoptedChangesData;
+    let changeDataFactory: ChangeDataFactory;
     logger.debug(`fetching data with params:
       repoId:${repoId}
       from:${JSON.stringify(from)}
@@ -2059,7 +2060,7 @@ export default class DgContentControls {
       attachmentsWikiUrl:${attachmentWikiUrl}
       linkedWiOptions:${JSON.stringify(linkedWiOptions)}`);
     try {
-      let changeDataFactory = new ChangeDataFactory(
+      changeDataFactory = new ChangeDataFactory(
         this.teamProjectName,
         repoId,
         from,
@@ -2210,7 +2211,10 @@ export default class DgContentControls {
           .trim()
           .toLowerCase() === 'required-states-and-modes';
       if (isSvdChangesControl) {
-        const releaseZipFileName = await this.resolveSvdReleaseZipFileName(rangeType, to);
+        const releaseZipFileName = await this.resolveSvdReleaseZipFileName(
+          rangeType,
+          changeDataFactory.getResolvedTo(),
+        );
         const releaseFileControlTitle = 'release-file-content-control';
         contentControls.push(
           ...(await this.addReleaseFileContentControl(releaseFileControlTitle, releaseZipFileName)),

--- a/src/factories/ChangeDataFactory.ts
+++ b/src/factories/ChangeDataFactory.ts
@@ -201,15 +201,23 @@ export default class ChangeDataFactory {
       logger.info(`[SVD ${svdId}] phase=resolveIds ${Date.now() - resolveStart}ms (from=${this.from}, to=${this.to})`);
       let recentReleaseArtifactInfo: any[] = [];
       if (this.rangeType === 'release') {
-        try {
-          recentReleaseArtifactInfo = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(
-            this.teamProject
-          );
-        } catch (error: any) {
+        const toReleaseId = Number(this.to);
+        if (!Number.isFinite(toReleaseId) || toReleaseId <= 0) {
           logger.warn(
-            `fetchSvdData: release-components lookup failed, skipping optional section: ${error?.message || error}`
+            `fetchSvdData: release-components lookup skipped — release id not resolved (to=${this.to})`
           );
-          recentReleaseArtifactInfo = [];
+        } else {
+          try {
+            recentReleaseArtifactInfo = await pipelinesDataProvider.GetRecentReleaseArtifactInfo(
+              this.teamProject,
+              toReleaseId
+            );
+          } catch (error: any) {
+            logger.warn(
+              `fetchSvdData: release-components lookup failed, skipping optional section: ${error?.message || error}`
+            );
+            recentReleaseArtifactInfo = [];
+          }
         }
       }
       const releaseComponentsCount = recentReleaseArtifactInfo?.length || 0;
@@ -635,6 +643,10 @@ export default class ChangeDataFactory {
 
   public getResolvedContextName(): string {
     return this.resolvedContextName;
+  }
+
+  public getResolvedTo(): string | number {
+    return this.to;
   }
 
   //#endregion public methods
@@ -1332,8 +1344,9 @@ export default class ChangeDataFactory {
             String(requestedReleaseDefinitionId)
           );
           const releases = history?.value || [];
-          if (releases.length > 0) {
-            latestReleaseId = releases[0].id;
+          const candidate = releases.find((r: any) => r.status !== 'abandoned');
+          if (candidate) {
+            latestReleaseId = candidate.id;
           }
         }
       } catch (e: any) {
@@ -1355,6 +1368,11 @@ export default class ChangeDataFactory {
       }
 
       if (!latestReleaseId) {
+        // Leaves this.to unresolved (non-finite/blank) on purpose: callers downstream
+        // (e.g. the GetRecentReleaseArtifactInfo guard in fetchSvdData) treat a
+        // non-finite/<=0 this.to as "unresolved" and skip release-scoped lookups
+        // rather than fetch with an invalid id. Keep this early-return contract in
+        // sync with any guard that reads this.to after resolveReleaseIds() runs.
         logger.warn(`Could not find a valid latest release for definition #${requestedReleaseDefinitionId}`);
         return;
       }

--- a/src/test/controllers-test/DgContentControls.svdReleaseFileControl.test.ts
+++ b/src/test/controllers-test/DgContentControls.svdReleaseFileControl.test.ts
@@ -55,6 +55,7 @@ describe('DgContentControls SVD release-file-content-control generation', () => 
       getAdoptedData: jest.fn().mockReturnValue([]),
       getAttachmentMinioData: jest.fn().mockReturnValue([]),
       getResolvedContextName: jest.fn().mockReturnValue(''),
+      getResolvedTo: jest.fn().mockReturnValue('17'),
     }));
   });
 

--- a/src/test/factories-test/ChangeDataFactory.test.ts
+++ b/src/test/factories-test/ChangeDataFactory.test.ts
@@ -1162,6 +1162,47 @@ describe('ChangeDataFactory', () => {
         ).toBe(true);
       });
 
+      it('passes the resolved release id to GetRecentReleaseArtifactInfo, not just the project name', async () => {
+        changeDataFactory.rangeType = 'release';
+        changeDataFactory.from = '14';
+        changeDataFactory.to = '16';
+        mockPipelinesDataProvider.GetRecentReleaseArtifactInfo.mockResolvedValue([]);
+        jest.spyOn(changeDataFactory, 'fetchChangesData').mockImplementation(async () => {
+          changeDataFactory['rawChangesArray'] = [];
+        });
+
+        await changeDataFactory.fetchSvdData();
+
+        expect(mockPipelinesDataProvider.GetRecentReleaseArtifactInfo).toHaveBeenCalledWith(
+          expect.any(String),
+          Number(changeDataFactory.to)
+        );
+      });
+
+      it('should skip release-components lookup when release id is unresolved (empty or invalid)', async () => {
+        changeDataFactory.rangeType = 'release';
+        changeDataFactory.from = '14';
+        changeDataFactory.to = ''; // Unresolved release ID
+        jest.spyOn(changeDataFactory, 'fetchChangesData').mockImplementation(async () => {
+          changeDataFactory['rawChangesArray'] = [
+            {
+              artifact: { name: 'Repo 1' },
+              changes: [{ workItem: { id: 1, fields: {}, _links: {} } }],
+              nonLinkedCommits: [],
+            },
+          ];
+        });
+
+        await changeDataFactory.fetchSvdData();
+
+        // Should NOT call GetRecentReleaseArtifactInfo when to is invalid
+        expect(mockPipelinesDataProvider.GetRecentReleaseArtifactInfo).not.toHaveBeenCalled();
+        // Should log a distinct "skipped" warning, not a "failed" warning
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.stringContaining('release-components lookup skipped')
+        );
+      });
+
       it('should skip changes and non-associated-commits when there are no raw changes', async () => {
         // No recent release artifacts
         mockPipelinesDataProvider.GetRecentReleaseArtifactInfo.mockResolvedValue([]);
@@ -5155,6 +5196,48 @@ describe('ChangeDataFactory', () => {
         expect(factory.from).toBe(10);
         expect(factory.to).toBe(20);
         expect(factory.getResolvedContextName()).toBe('release-MyRelease-2-0-0');
+      });
+
+      it('resolveReleaseIds Scenario 4: to auto-discovery skips an abandoned newest release', async () => {
+        const factory = new ChangeDataFactory(
+          defaultParams.teamProject,
+          defaultParams.repoId,
+          '',
+          '',
+          'release',
+          defaultParams.linkTypeFilterArray,
+          defaultParams.branchName,
+          defaultParams.includePullRequests,
+          defaultParams.includePullRequestWorkItems,
+          defaultParams.attachmentWikiUrl,
+          defaultParams.includeChangeDescription,
+          defaultParams.includeCommittedBy,
+          mockDgDataProvider,
+          defaultParams.attachmentsBucketName,
+          defaultParams.minioEndPoint,
+          defaultParams.minioAccessKey,
+          defaultParams.minioSecretKey,
+          defaultParams.PAT
+        ) as any;
+
+        const pipelines = {
+          GetReleaseHistory: jest.fn().mockResolvedValue({
+            value: [
+              { id: 21, status: 'abandoned' },
+              { id: 20, status: 'active' },
+            ]
+          }),
+          findPreviousSuccessfulRelease: jest.fn().mockResolvedValue(10),
+          GetReleaseByReleaseId: jest.fn().mockImplementation((_tp: string, id: number) => {
+            if (id === 20) return Promise.resolve({ id: 20, name: '2.0.0', releaseDefinition: { id: 1, name: 'MyRelease' } });
+            return Promise.resolve(undefined);
+          }),
+        } as any;
+
+        await factory.resolveReleaseIds(pipelines);
+
+        expect(factory.to).toBe(20);
+        expect(pipelines.GetReleaseByReleaseId).toHaveBeenCalledWith(defaultParams.teamProject, 20);
       });
 
       it('resolvePipelineIds Scenario 1: from is explicit, to is empty', async () => {


### PR DESCRIPTION
…nents lookup

Three related fixes to why auto/script-mode SVD generation diverges from manual/UI generation over the same release range:

- release-file-content-control filename generation read the original request 'to' parameter (blank in auto-discovery mode) instead of the release id ChangeDataFactory resolves internally; added ChangeDataFactory.getResolvedTo() so the controller reads the resolved value.
- release-range auto-discovery ('to') now skips abandoned releases, matching the filter already applied on the 'from' side.
- the release-components lookup (GetRecentReleaseArtifactInfo call site) is now guarded: if release id resolution silently failed, the call is skipped entirely with a distinct "id not resolved" warning instead of proceeding with an invalid id and logging a misleading "lookup failed".

Includes a comment documenting the implicit contract between resolveReleaseIds()'s early-return (leaves this.to unresolved on purpose) and the downstream guard that depends on it.